### PR TITLE
Add TTL version of ontology for OLS

### DIFF
--- a/probonto4ols.ttl
+++ b/probonto4ols.ttl
@@ -1,0 +1,18444 @@
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+<http://www.probonto.org/ontology>
+      a       owl:Ontology ;
+      owl:versionInfo "2.5.0" .
+
+<http://www.probonto.org/ontology#PROB_k0001285>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "kurtosis of Sinh-Arcsinh-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "kurtosis of Sinh-Arcsinh-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "SinhArcsinh2.kurtosis"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\delta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\delta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "kurtosis"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "kurtosis"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001359>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Standard-Power-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Standard-Power-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StandardPower1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta  > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001132>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label """noncentrality
+parameter of Noncentral-chi-squared-1""" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              """noncentrality
+parameter of Noncentral-chi-squared-1"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NoncentralChiSquared1.noncentrality"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\delta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\delta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              """noncentrality
+parameter"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "noncentrality"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000187>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Inverse-Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Inverse-Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\beta^2}{(\\alpha-1)^2(\\alpha-2)} \\text{ for } \\alpha > 2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000312>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000425>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Exponential 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Exponential 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001200>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Wigner Semicircle 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Wigner Semicircle 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "R^2/4"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000740>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of GeneralizedPoisson2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of GeneralizedPoisson2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedPoisson2.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001089>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of LKJ Correlation 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of LKJ Correlation 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\propto |J| \\det(LL^T)^{(\\eta-1)} = \\prod_{k=2}^{K}L_{kk}^{K-k+2\\eta-2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000762>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Generalized Poisson 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Generalized Poisson 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu (1+\\alpha \\mu)^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000720>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Multivariate Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Multivariate Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(2\\pi)^{-\\frac{k}{2}}|\\Sigma|^{-\\frac{1}{2}}\\, e^{ -\\frac{1}{2}(x-\\mu)'\\Sigma^{-1}(x-\\mu) }"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000213>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Inverse Gaussian 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Inverse Gaussian 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sqrt{\\frac{\\lambda}{2\\pi x^3}} \\exp\\Big(-\\frac{\\lambda}{2\\mu^2 x}(x-\\mu)^2\\Big)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "sqrt(lambda/(2*pi*x^3) ) * exp(-lambda/(2*mu^2 x) * (x-mu)^2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001244>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Chi 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Chi 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{2^{1-k/2} x^{k-1} e^{-x^2 / 2} }{\\Gamma\\left(\\frac{k}{2}\\right)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "2^(1-k/2) * x^(k-1) * exp(-x^2/2) / gamma(k/2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000167>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "number of failures of Negative-Binomial-4" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "number of failures of Negative-Binomial-4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial4.numberOfFailures"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "r"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "r > 0, r \\in N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "number of failures"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "numberOfFailures"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001048>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Trapezoidal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Trapezoidal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\dfrac{2^2}{72(d+c-a-b)^2} \\big(d^4+2cd^3-3bd^3-3ad^3 \\\\
+-3bcd^2 - 3acd^2 + 4b^2d^2 + 4abd^2 \\\\
++4a^2d^2 + 2c^3d - 3bc^2d - 3ac^2d \\\\
++4b^2cd + 4abcd + 4a^2cd - 3b^3d - 3ab^2d \\\\
+-3a^2bd - 3a^3d + c^4 - 3bc^3 - 3ac^3 + 4b^2c^2 \\\\
++4abc^2 + 4a^2c^2 - 3b^3c - 3ab^2c - 3a^2bc \\\\
+-3a^3c + b^4 + 2ab^3 + 2a^3b + a4 \\big)"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000291>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Normal 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sqrt{\\frac{\\tau}{2 \\pi}} e^{-\\frac{\\tau}{2}(x-\\mu)^2}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "sqrt(tau/(2*pi))*exp(-tau/2*(x-mu)^2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000127>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Hypergeometric 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Hypergeometric 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "{{{K \\choose k} {{N-K} \\choose {n-k}}}\\over {N \\choose n}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "choose(K,k)*choose(M-K,n-k)/choose(M,n)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000362>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Pareto Type I" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Pareto Type I"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\alpha\\,x_m^\\alpha}{x^{\\alpha+1}}\\text{ for }x\\ge x_m"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(alpha * x_m^alpha) / x^(alpha+1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000955>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 3 and Log-Normal 2 whereby \\\\mu = \\\\logm, v = \\\\sigma^2" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000478> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000453> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = \\log(m), v = \\sigma^2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal3(m,\\sigma) \\rightarrow LogNormal2(\\mu,v)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000188>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Inverse-Gamma-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Inverse-Gamma-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "InverseGamma1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha>0, \\alpha \\in  R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001131>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Noncentral chi-squared 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Noncentral chi-squared 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "2(n + 2 \\delta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001284>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "skewness of Sinh-Arcsinh-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "skewness of Sinh-Arcsinh-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "SinhArcsinh2.skewness"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\epsilon"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\epsilon \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "skewness"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "skewness"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000293>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Normal 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001201>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "radius of Wigner-Semicircle-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "radius of Wigner-Semicircle-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "WignerSemicircle1.radius"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "R > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "radius"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "radius"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000424>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Exponential 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Exponential 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lambda^{-1} \\ln(2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000100>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Hyperbolic secant 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Hyperbolic secant 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\pi + 2 \\text{ arctan}(\\text{sinh}(\\pi x))}{2\\pi}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(pi + 2*arctan(sinh(pi*x)))/(2*pi)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000311>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000761>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Generalized Poisson 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Generalized Poisson 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001088>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "LKJ Correlation 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "LKJ Correlation 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LKJCorrelation2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001089> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "L"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "\\text{Cholesky factor of a symmetric positive-definite matrix with unit diagonal (i.e., a correlation matrix)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001090> .
+
+<http://www.probonto.org/ontology#PROB_k0001159>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "upper bound of Two-Sided-Power-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "upper bound of Two-Sided-Power-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "TwoSidedPower1.upperBound"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "b \\in R, b > m"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "upper bound"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "upperBound"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001245>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Chi 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Chi 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{ \\gamma\\left(\\frac{k}{2},\\,\\frac{x^2}{2}\\right) }{ \\Gamma\\left(\\frac{k}{2}\\right) }"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "Igamma(k/2,x^2/2,lower=T) / gamma(k/2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001049>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "Lower bound of Trapezoidal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Lower bound of Trapezoidal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Trapezoidal1.lowerBound"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "a < d"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "Lower bound"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "lowerBound"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000292>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Normal 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac12\\left[1 + \\text{erf}\\left( \\frac{x-\\mu}{\\sqrt{1/\\tau}\\sqrt{2}}\\right)\\right]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/2*(1+erf((x-mu)/(sqrt(1/tau)*sqrt(2)))) "^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000212>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Inverse Gaussian 1" , "Wald"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Inverse Gaussian 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "InverseGaussian1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000213> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000214> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000215> , <http://www.probonto.org/ontology#PROB_k0000216> .
+
+<http://www.probonto.org/ontology#PROB_k0000168>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "success probability of Negative-Binomial-4" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "success probability of Negative-Binomial-4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial4.probability"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "p \\in (0,1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "success probability"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "probability"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000361>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Pareto Type I" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Pareto Type I"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ParetoTypeI1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000362> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000363> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000364> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000365> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000366> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000367> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [x_m, +\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000368> , <http://www.probonto.org/ontology#PROB_k0000369> .
+
+<http://www.probonto.org/ontology#PROB_k0000128>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Hypergeometric 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Hypergeometric 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1-{{{n \\choose {k+1}}{{N-n} \\choose {K-k-1}}}\\over {N \\choose K}} \\,_3F_2\\!\\!\\left[\\begin{array}{c}1,\\ k+1-K,\\ k+1-n \\\\ k+2,\\ N+k+2-K-n\\end{array};1\\right]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "cumsum(PMF)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000789>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "success probability of Geometric-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "success probability of Geometric-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Geometric1.probability"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "0 < p < 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "success probability"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "probability"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000956>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Log-Normal 5 and Log-Normal 6 whereby m=\\\\exp\\\\mu, 
+\\\\sigma_g= \\\\exp1/\\\\sqrt{\\\\tau}""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000526> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000553> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """m=\\exp(\\mu), 
+\\sigma_g= \\exp(1/\\sqrt{\\tau})"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal5(\\mu,\\tau) \\rightarrow LogNormal6(m,\\sigma_g)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001202>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Makeham 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Makeham 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Makeham1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001203> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001204> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0001206> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0001205> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001207> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0001208> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0001209> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001210> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001213> , <http://www.probonto.org/ontology#PROB_k0001212> , <http://www.probonto.org/ontology#PROB_k0001211> .
+
+<http://www.probonto.org/ontology#PROB_k0001134>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Benford 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Benford 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Benford1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0001135> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001136> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0001138> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0001137> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001139> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0001140> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0001141> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001142> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{1,2,...,9\\}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000294>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Normal 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001287>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Zipf 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Zipf 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\frac{1}{x^\\alpha H_{n,\\alpha}} \\\\
+H_{n,\\alpha} = \\sum^n_{i=1} (1/i)^\\alpha"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """1 / (x^alpha * Hfunc(n,alpha))\\\\
+Hfunc = function(n,alpha) {
+  Hsum=0;
+  for(i in 1:n) {
+    Hsum = Hsum + (1/i)^alpha
+  }
+  return(Hsum)
+}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000423>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Exponential 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Exponential 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lambda^{-1}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000649>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Generalized Gamma 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Generalized Gamma 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "b^2\\{\\Gamma(c+2/k)/\\Gamma(c)-[\\Gamma(c+1/k)/\\Gamma(c)]^2\\}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000764>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "dispersion of Generalized-Poisson-3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "dispersion of Generalized-Poisson-3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedPoisson3.dispersion"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha > -1, \\alpha \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "dispersion"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "dispersion"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000189>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Inverse-Gamma-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Inverse-Gamma-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "InverseGamma1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta>0, \\beta \\in  R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001357>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Standard Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Standard Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(1/2)^{1/\\beta}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001087>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape paremeter of Amoroso-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape paremeter of Amoroso-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Amoroso1.shape2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape paremeter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000101>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Hyperbolic secant 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Hyperbolic secant 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000310>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001246>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Chi 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Chi 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu = \\sqrt{2}\\,\\frac{\\Gamma((k+1)/2)}{\\Gamma(k/2)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000215>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Inverse-Gaussian-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Inverse-Gaussian-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "InverseGaussian1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\lambda > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000169>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Zero-Inflated Generalized Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Zero-Inflated Generalized Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ZeroInflatedGeneralizedPoisson1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000170> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000171> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000172> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000173> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "y"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "y \\in \\{0,1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000174> , <http://www.probonto.org/ontology#PROB_k0000176> , <http://www.probonto.org/ontology#PROB_k0000175> .
+
+<http://www.probonto.org/ontology#PROB_k0000957>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Laplace 1 and Laplace 2 whereby \\\\tau=1/b" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000256> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000283> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\tau=1/b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Laplace1(\\mu,b) \\rightarrow Laplace2(\\mu,\\tau)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000364>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Pareto Type I" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Pareto Type I"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+\\infty & \\text{for }\\alpha\\le 1 \\\\
+\\frac{\\alpha\\,x_m}{\\alpha-1} & \\text{for }\\alpha>1
+\\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000129>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Hypergeometric 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Hypergeometric 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "n {K\\over N}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000295>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Normal 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000422>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Exponential 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Exponential 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\exp(-\\lambda x)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp(-lambda*x)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000648>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Generalized Gamma 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Generalized Gamma 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "a+b(c-1/k)^{1/k}, c>1/k"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001133>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degrees of freedom of Noncentral-chi-squared-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degrees of freedom of Noncentral-chi-squared-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NoncentralChiSquared1.degreesOfFreedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "n"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "n \\in N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degrees of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "degreesOfFreedom"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000958>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Logistic 1 and Log-Logistic 2 whereby \\\\lambda=1/\\\\alpha, \\\\kappa=\\\\beta" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000377> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000402> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\lambda=1/\\alpha, \\kappa=\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogLogistic1(\\alpha,\\beta) \\rightarrow LogLogistic2(\\lambda,\\kappa)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001358>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Standard Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Standard Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\beta}{(2+\\beta)(1+\\beta)^2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000763>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Generalized-Poisson-3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Generalized-Poisson-3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedPoisson3.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001286>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Zipf 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Zipf 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Zipf1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0001287> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001288> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001289> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001290> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in \\{1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001292> , <http://www.probonto.org/ontology#PROB_k0001291> .
+
+<http://www.probonto.org/ontology#PROB_k0001086>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Amoroso-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Amoroso-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Amoroso1.shape1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha \\in R, \\alpha > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001203>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Makeham 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Makeham 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(\\gamma+\\delta\\kappa^x) e^{-\\gamma x -\\delta (\\kappa^x - 1)/\\log(\\kappa)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(gamma+delta*kappa^x)*exp(-gamma*x -delta*(kappa^x - 1)/log(kappa) )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000102>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Hyperbolic secant 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Hyperbolic secant 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000214>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Inverse Gaussian 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Inverse Gaussian 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Phi\\left(\\sqrt{\\frac{\\lambda}{x}} \\left(\\frac{x}{\\mu}-1 \\right)\\right) +\\exp\\left(\\frac{2 \\lambda}{\\mu}\\right) \\Phi\\left(-\\sqrt{\\frac{\\lambda}{x}}\\left(\\frac{x}{\\mu}+1 \\right)\\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "pnorm(sqrt(lambda/x) * (x/mu-1)) + exp(2*lambda/mu) * pnorm(-sqrt(lambda/x) * (x/mu+1))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000000>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Bernoulli 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Bernoulli 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Bernoulli1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000002> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001074> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000003> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000004> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000005> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000006> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,1\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000007> .
+
+<http://www.probonto.org/ontology#PROB_k0001047>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Trapezoidal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Trapezoidal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\dfrac{2}{6(d+c-a-b)} \\big(d^2+cd+c^2-b^2-ab-a^2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001247>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Chi 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Chi 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sqrt{k-1} \\text{ for }k\\ge 1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000363>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Pareto Type I" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Pareto Type I"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1-\\left(\\frac{x_m}{x}\\right)^\\alpha \\text{ for } x \\ge x_m"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1-(x_m/x)^alpha"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001220>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\alpha^2 \\beta}{(2+\\beta)(1+\\beta)^2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000744>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Multivariate Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Multivariate Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\text{no analytic expression}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001204>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Makeham 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Makeham 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1 - e^{-(\\gamma x \\log(\\kappa) +\\delta \\kappa^x -\\delta)/\\log(\\kappa)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1 - exp( -(gamma*x*log(kappa)+delta*kappa^x -delta)/log(kappa) )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000429>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Log-Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Log-Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{x\\sigma\\sqrt{2\\pi}}\\ e^{-\\frac{\\left(\\log x-\\mu\\right)^2}{2\\sigma^2}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(x*sigma*sqrt(2*pi)) * exp((-(log(x)-mu)^2)/(2*sigma^2))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000766>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Multivariate Normal 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Multivariate Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(2\\pi)^{-\\frac{k}{2}}(LL^T)^{-\\frac{1}{2}}\\, e^{ -\\frac{1}{2}(x-\\mu)^T(LL^T)^{-1}(x-\\mu) }"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001260>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Sinh-Arcsinh-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Sinh-Arcsinh-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "SinhArcsinh1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma> 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001136>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Benford 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Benford 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\log_{10}\\left(1+x\\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "log10(1+x)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000103>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Hyperbolic secant 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Hyperbolic secant 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001331>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Johnson-SU-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Johnson-SU-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSU1.shape1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\gamma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\gamma \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000690>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Generalized Negative Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Generalized Negative Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedNegativeBinomial1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000691> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000692> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000693> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000694> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in \\{0,1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000697> , <http://www.probonto.org/ontology#PROB_k0000695> , <http://www.probonto.org/ontology#PROB_k0000696> .
+
+<http://www.probonto.org/ontology#PROB_k0000826>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Generalized Gamma 2 and Exponential 1 whereby k=c=1, a=0, b=1/\\\\lambda" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000644> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000418> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "k=c=1, a=0, b=1/\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "GeneralizedGamma2(a,b,c,k) \\rightarrow Exponential1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{forbes2011statistical}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000786>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Geometric 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Geometric 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\left\\lceil \\frac{-1}{\\log_2(1-p)}-1 \\right\\rceil \\text{ (not unique if } -1/\\log_2(1-p)-1 \\text{ is an integer)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001261>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "left hand tail of Sinh-Arcsinh-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "left hand tail of Sinh-Arcsinh-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "SinhArcsinh1.skewness"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\nu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\nu > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "left hand tail"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "skewness"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000449>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Exponential 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Exponential 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lambda^{-1} \\ln(2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000027>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Weibull-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Weibull-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Weibull2.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "v"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000951>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 6 and Log-Normal 4 whereby m=m, cv=\\\\sqrt{\\\\exp\\\\!\\\\big\\\\log^2\\\\sigma_g\\\\big-1}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000553> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000500> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "m=m, cv=\\sqrt{\\exp\\!\\big(\\log^2(\\sigma_g)\\big)-1}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal6(m,\\sigma_g) \\rightarrow LogNormal4(m,cv)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001156>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Two-Sided Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Two-Sided Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{b-m+mn+a}{n+1}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000163>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Negative Binomial 4" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Negative Binomial 4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1 - I_{p}(k+1,r)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1 - Rbeta(p, k+1, r,lower = T)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001280>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Sinh-Arcsinh 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Sinh-Arcsinh 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """PDF(x;\\mu,\\sigma,\\epsilon,\\delta) = \\phi[H(x;\\mu,\\sigma,\\epsilon,\\delta)] \\, h(x;\\mu,\\sigma,\\epsilon,\\delta)\\\\
+h(x;\\mu,\\sigma,\\epsilon,\\delta) = \\frac{\\delta\\cosh\\left(\\delta\\,\\mbox{arcsinh}\\left(\\dfrac{x-\\mu}{\\sigma}\\right)-\\epsilon\\right)}{\\sigma \\sqrt{1+\\left(\\dfrac{x-\\mu}{\\sigma}\\right)^2}}\\\\
+H(x;\\mu,\\sigma,\\epsilon,\\delta) = \\sinh\\left(\\delta\\,\\mbox{arcsinh}\\left(\\dfrac{x-\\mu}{\\sigma}\\right)-\\epsilon\\right)\\\\
+\\phi = \\frac1{\\sqrt{2\\pi}} \\exp(-x^2/2)
+"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """PDF = function(x,mu,sigma,epsilon,delta) { phi(Hfunc(x,mu,sigma,epsilon,delta)) * hfunc(x,mu,sigma,epsilon,delta) }
+hfunc = function(x,mu,sigma,epsilon,delta) { (delta*cosh(delta*asinh((x-mu)/sigma)-epsilon))/(sigma*sqrt(1+((x-mu)/sigma)^2)) }
+Hfunc = function(x,mu,sigma,epsilon,delta) { sinh(delta*asinh((x-mu)/sigma)-epsilon) }
+phi = function(x) { 1/(sqrt(2*pi))*exp(-x^2/2) }"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000123>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "np(1 - p)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001240>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of YuleSimon1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of YuleSimon1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000867>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Standard Uniform 1 and Exponential 1 whereby -\\\\frac{1}{\\\\lambda} \\\\logX" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000587> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000418> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "-\\frac{1}{\\lambda} \\log(X)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StandardUniform1(0,1) \\rightarrow Exponential1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/StandarduniformExponentialB.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000891>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Gamma 1 and Beta 1 whereby X1, X2 \\\\sim Gamma1k,\\\\theta \\\\text{ and } Y = X1/X1+X2 \\\\Rightarrow Y \\\\sim Beta1\\\\alpha,\\\\beta " ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000571> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000057> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "X1, X2 \\sim Gamma1(k,\\theta) \\text{ and } Y = X1/(X1+X2) \\Rightarrow Y \\sim Beta1(\\alpha,\\beta) "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Gamma1(k,\\theta) \\rightarrow Beta1(\\alpha,\\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/GammaBeta.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000743>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Multivariate Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Multivariate Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(2\\pi)^{-d/2}|T|^{\\frac{1}{2}}\\, \\exp\\big( -\\frac{1}{2}(x-\\mu)' T (x-\\mu) \\big)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001205>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Makeham 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Makeham 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\gamma + \\delta \\kappa^x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "gamma + delta*kappa^x"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001221>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale parameter of Power-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale parameter of Power-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Power1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000765>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Multivariate Normal 3" , "Cholesky Parameterization"^^<en> , "Multivariate Normal Distribution"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Multivariate Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateNormal3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000766> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000768> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000769> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000770> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in R^K"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000771> , <http://www.probonto.org/ontology#PROB_k0000772> .
+
+<http://www.probonto.org/ontology#PROB_k0000428>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Log-Normal 1" , "lognormal"^^<en> , "Galton"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Log-Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000429> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000430> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000431> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000432> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000433> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000434> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000435> , <http://www.probonto.org/ontology#PROB_k0000436> .
+
+<http://www.probonto.org/ontology#PROB_k0000090>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Beta-binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Beta-binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "BetaBinomial1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000091> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000092> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000093> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000094> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,\\dots,n\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000096> , <http://www.probonto.org/ontology#PROB_k0000097> , <http://www.probonto.org/ontology#PROB_k0000095> .
+
+<http://www.probonto.org/ontology#PROB_k0001135>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Benford 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Benford 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\log_{10}\\left(1+\\frac1x\\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "log10(1+1/x)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001332>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Johnson-SU-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Johnson-SU-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSU1.shape2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\delta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\delta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000104>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Hyperbolic secant 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Hyperbolic secant 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000026>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "lambda of Weibull-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "lambda of Weibull-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Weibull2.lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "lambda"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000691>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Generalized Negative Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Generalized Negative Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{m}{m+\\beta x} {m+\\beta x \\choose x} \\theta^x (1-\\theta)^{m+\\beta x-x}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """m/(m+beta*x) * choose(m+beta*x,x)*theta^x * (1-theta)^(m+beta*x-x)
+"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000448>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Exponential 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Exponential 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\beta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000952>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Zero-Inflated Generalized Poisson 1 and Zero-inflated Poisson 1 whereby \\\\alpha=0, \\\\lambda=\\\\mu" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000169> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000197> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\alpha=0, \\lambda=\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "ZeroInflatedGeneralizedPoisson1(\\mu,\\alpha,p0) \\rightarrow ZeroInflatedPoisson1(\\lambda,\\pi)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{famoye2006zero}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000827>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 2 and Negative Binomial 5 whereby \\\\alpha = 1/\\\\tau, \\\\beta = 1 / \\\\tau \\\\lambda" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000105> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000190> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\alpha = 1/\\tau, \\beta = 1 / (\\tau \\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial2(\\lambda, \\tau) \\rightarrow NegativeBinomial5(\\alpha, \\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000785>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Geometric 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Geometric 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1-p}{p}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000164>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Negative Binomial 4" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Negative Binomial 4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{pr}{1-p}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001155>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Two-Sided Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Two-Sided Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+-\\frac{-b+a+(x-a)^n (m-a)^{1-n}}{b-a} &\\text{ for } a < x < m \\\\
+\\frac{(b-x)^n (b-m)^{1-n}}{b-a} &\\text{ for } m \\leq x < b 
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """SF1 = function(x,a,b,m,n) { -(-b+a+(x-a)^n*(m-a)^(1-n))/(b-a) }
+SF2 = function(x,a,b,m,n) { ((b-x)^n*(b-m)^(1-n))/(b-a) }"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001241>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of YuleSimon1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of YuleSimon1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\rho^2}{(\\rho-1)^2(\\rho-2)} \\text{ for } \\rho>2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000890>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 3 and Negative Binomial 4 whereby r = \\\\phi, p = \\\\mu / \\\\phi + \\\\mu" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000135> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000161> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "r = \\phi, p = \\mu / (\\phi + \\mu)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial3(\\mu, \\phi) \\rightarrow NegativeBinomial4(r,p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000124>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "number of trials of Binomial-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "number of trials of Binomial-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Binomial1.numberOfTrials"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "n"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "n \\in N, n \\ge 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "number of trials"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "numberOfTrials"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000866>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 4 and Negative Binomial 2 whereby \\\\tau=1/r, \\\\lambda = \\\\frac{rp}{1-p}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000161> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000105> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\tau=1/r, \\lambda = \\frac{rp}{1-p}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial4(r,p) \\rightarrow NegativeBinomial2(\\lambda, \\tau)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """ProbOnto spec \\\\
+\\cite{cameron2013regression}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001222>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Power-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Power-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Power1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta  > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000742>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Multivariate Normal 2" , "Multivariate Gaussian 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Multivariate Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateNormal2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000743> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000744> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000745> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000746> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000747> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in R^k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000749> , <http://www.probonto.org/ontology#PROB_k0000748> .
+
+<http://www.probonto.org/ontology#PROB_k0001206>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Makeham 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Makeham 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "e^{-(\\gamma x \\log(\\kappa) +\\delta \\kappa^x -\\delta)/\\log(\\kappa)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp( -(gamma*x*log(kappa)+delta*kappa^x -delta)/log(kappa) )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001138>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Benford 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Benford 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1-\\log_{10}(x)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1-log10(x)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000768>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Multivariate Normal 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Multivariate Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000105>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Negative Binomial 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Negative Binomial 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000106> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000107> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000108> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000109> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000110> , <http://www.probonto.org/ontology#PROB_k0000111> .
+
+<http://www.probonto.org/ontology#PROB_k0000340>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Ordered Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Ordered Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "OrderedLogistic1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000341> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{1,\\dots, K\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000344> , <http://www.probonto.org/ontology#PROB_k0000343> .
+
+<http://www.probonto.org/ontology#PROB_k0000091>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Beta-binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Beta-binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "{n \\choose k}\\frac{B(k+\\alpha,n-k+\\beta)}{B(\\alpha,\\beta)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "choose(n,k) * beta(k+alpha,n-k+beta) / beta(alpha,beta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000427>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "rate or inverse scale of Exponential-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "rate or inverse scale of Exponential-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Exponential1.rate"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\lambda > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "rate or inverse scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "rate"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001283>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Sinh-Arcsinh-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Sinh-Arcsinh-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "SinhArcsinh2.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma> 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000447>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Exponential 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Exponential 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "e^{-x/\\beta}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp(-x/beta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001282>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Sinh-Arcsinh-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Sinh-Arcsinh-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "SinhArcsinh2.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000360>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Logit-Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Logit-Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogitNormal1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma > 0, \\sigma \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001158>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "Lower bound of Two-Sided-Power-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Lower bound of Two-Sided-Power-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "TwoSidedPower1.lowerBound"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "a \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "Lower bound"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "lowerBound"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000125>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "success probability in each trial of Binomial-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "success probability in each trial of Binomial-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Binomial1.probability"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "p \\in [0,1]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "success probability in each trial"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "probability"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001263>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Zeta 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Zeta 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Zeta1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0001264> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001265> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001266> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001267> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in \\{1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001268> .
+
+<http://www.probonto.org/ontology#PROB_k0000953>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Standard Uniform 1 and Log-Logistic 2 whereby \\\\text{If } X \\\\sim StandardUniform1 \\\\text{ and } Y=\\\\frac{1}{\\\\lambda} \\\\Big \\\\frac{1-X}{X} \\\\Big^{1/\\\\kappa} \\\\Rightarrow Y\\\\sim LogLogistic2\\\\lambda,\\\\kappa" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000587> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000402> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X \\sim StandardUniform1 \\text{ and } Y=\\frac{1}{\\lambda} \\Big( \\frac{1-X}{X} \\Big)^{1/\\kappa} \\Rightarrow Y\\sim LogLogistic2(\\lambda,\\kappa)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StandardUniform1 \\rightarrow LogLogistic2(\\lambda,\\kappa)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000029>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Bernoulli 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Bernoulli 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+logit^{-1}(\\alpha) & \\text{for }k=1 \\\\ 
+1 - logit^{-1}(\\alpha) & \\text{for }k=0
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """invLogit = function(x) { exp(x)/(1+exp(x)) } 
+invLogit(alpha1) for k = 1 
+1-invLogit(alpha1) for k = 0"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000165>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Negative Binomial 4" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Negative Binomial 4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+\\lfloor \\frac{p(r-1)}{1-p} \\rfloor & \\text{for } r > 1 \\\\ 
+0 & \\text{for } r \\leq 1 
+\\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000211>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Burr-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Burr-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Burr1.shape2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "k > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000828>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Skew Normal and Standard Normal 1 whereby \\\\text{If } X \\\\sim SkewNormal1\\\\mu,\\\\sigma,0 \\\\text{ then } X \\\\sim StandardNormal1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000535> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000562> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X \\sim SkewNormal1(\\mu,\\sigma,0) \\text{ then } X \\sim StandardNormal1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "SkewNormal1(\\mu,\\sigma,\\alpha) \\rightarrow StandardNormal1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\url{https://en.wikipedia.org/wiki/Skew_normal_distribution}\\\\
+\\url{http://azzalini.stat.unipd.it/SN/Intro/intro.html}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000788>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Geometric 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Geometric 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1-p}{p^2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000893>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Generalized Gamma 1 and Generalized Gamma 3 whereby r=d/p, \\\\beta=p, \\\\mu = 1/a" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000621> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000670> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "r=d/p, \\beta=p, \\mu = 1/a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "GeneralizedGamma1(a,d,p) \\rightarrow GeneralizedGamma3(r,\\mu,\\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000869>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Generalized Gamma 1 and Gamma 1 whereby p=1, k=d, \\\\theta=a" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000621> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000571> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "p=1, k=d, \\theta=a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "GeneralizedGamma1(a,d,p) \\rightarrow Gamma1(k,\\theta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001242>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of YuleSimon1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of YuleSimon1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "YuleSimon1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\rho"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              " \\rho > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001207>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Makeham 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Makeham 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\text{mathematically intractable}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001223>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Maxwell Boltzmann 1" , "Maxwell"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Maxwell Boltzmann 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MaxwellBoltzmann1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001224> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001225> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001226> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0001227> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001228> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001229> .
+
+<http://www.probonto.org/ontology#PROB_k0001137>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Benford 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Benford 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\log_{10}\\left(1+\\frac1x\\right)}{1-\\log_{10}x}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "log10(1+1/x) / (1-log10(x))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000741>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "dispersion of GeneralizedPoisson2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "dispersion of GeneralizedPoisson2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedPoisson2.dispersion"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\delta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "max(-1,-\\mu/m) < \\delta < 1 \\text{ with } m (\\geq 4) \\text { the largest positive integer for which } \\mu + m \\delta > 0."^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "dispersion"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "dispersion"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000092>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Beta-binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Beta-binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Sigma_{i=1}^x f(i), x \\in \\{0,1,2,...\\} \\text{ with } f \\text{ the PMF}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "cumsum(PMF)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000106>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Negative Binomial 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Negative Binomial 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\Gamma(k+\\frac{1}{\\tau})}{k!\\; \\Gamma(\\frac{1}{\\tau})} \\Big(\\frac{1}{1+\\tau \\lambda} \\Big)^{\\frac{1}{\\tau}} \\Big(\\frac{\\lambda}{\\frac{1}{\\tau} + \\lambda} \\Big)^{k}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "gamma(k + 1/tau)/(factorial(k) * gamma(1/tau)) * 1/(1+tau*lambda)^(1/tau) * (lambda/(1/tau + lambda))^k"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000426>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Exponential 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Exponential 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lambda^{-2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001330>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Johnson SU 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Johnson SU 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac12\\left(1+  \\text{erf}\\left[\\frac{\\gamma + \\delta \\,\\text{arcsin}\\left[\\frac{x-\\mu}{\\sigma}\\right]}{\\sqrt{2}}\\right] \\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/2 *(1+  erf((gamma+delta*asinh((x-mu)/sigma))/sqrt(2)))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000954>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Logit Normal 1 and Normal 1 whereby X \\\\text{ is logit-normally distributed, then } Y = logitX= \\\\logX/1-X \\\\text{ is normally distributed}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000352> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "X \\text{ is logit-normally distributed, then } Y = logit(X)= \\log(X/(1-X)) \\text{ is normally distributed}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogitNormal1(\\mu,\\sigma) \\rightarrow Normal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/Logit-normal_distribution}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001157>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Two-Sided Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Two-Sided Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{-2mnb +2m^2n+a^2n+b^2n-2mna+2bm-2ba+2am-2m^2}{(n+1)^2(n+2)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000126>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Hypergeometric 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Hypergeometric 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Hypergeometric1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000127> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000128> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000129> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000130> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000131> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k\\, \\in\\, \\left\\{\\max{(0,\\, n+K-N)},\\, \\dots,\\, \\min{(n,\\, K )}\\right\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000133> , <http://www.probonto.org/ontology#PROB_k0000134> , <http://www.probonto.org/ontology#PROB_k0000132> .
+
+<http://www.probonto.org/ontology#PROB_k0001281>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Sinh-Arcsinh 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Sinh-Arcsinh 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """S_0(x;\\mu,\\sigma,\\epsilon,\\delta) = \\Phi[H(x;\\mu,\\sigma,\\epsilon,\\delta)]\\\\
+\\Phi(x) = \\frac12 (1 + erf(x/\\sqrt{2}))\\\\
+H(x;\\mu,\\sigma,\\epsilon,\\delta) = \\sinh\\left(\\delta\\,\\mbox{arcsinh}\\left(\\dfrac{x-\\mu}{\\sigma}\\right)-\\epsilon\\right)"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """S0func = function(x,mu,sigma,epsilon,delta) { PHI(Hfunc(x,mu,sigma,epsilon,delta)) }
+Hfunc = function(x,mu,sigma,epsilon,delta) { sinh(delta*asinh((x-mu)/sigma)-epsilon) }
+PHI = function(x) { 1/2 * (1 + erf(x/(sqrt(2)))) }"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000446>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Exponential 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Exponential 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1/\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/beta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000166>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Negative Binomial 4" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Negative Binomial 4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{pr}{(1-p)^2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000787>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Geometric 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Geometric 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000829>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Normal 1 and Log-Normal 1 whereby \\\\expX" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000428> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\exp(X)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Normal1(\\mu,\\sigma) \\rightarrow LogNormal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/NormalLognormal.pdf}\\\\
+\\cite{forbes2011statistical}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001262>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "right hand tail of Sinh-Arcsinh-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "right hand tail of Sinh-Arcsinh-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "SinhArcsinh1.kurtosis"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\tau"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\tau > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "right hand tail"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "kurtosis"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000028>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Bernoulli 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Bernoulli 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Bernoulli2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000029> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,1\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000031> .
+
+<http://www.probonto.org/ontology#PROB_k0000210>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Burr-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Burr-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Burr1.shape1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "c"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "c > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000290>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Gaussian"^^<en> , "Normal"^^<en> , "Normal 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Normal3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000291> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000292> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000293> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000294> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000295> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000296> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000297> , <http://www.probonto.org/ontology#PROB_k0000298> .
+
+<http://www.probonto.org/ontology#PROB_k0001243>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Chi 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Chi 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Chi1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001244> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001245> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001246> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0001247> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001248> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001249> .
+
+<http://www.probonto.org/ontology#PROB_k0000892>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label """relationship between Negative Binomial 1 and Normal 1 whereby \\\\mu = n1-p, 
+n \\\\rightarrow \\\\infty""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000074> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """\\mu = n(1-p), 
+n \\rightarrow \\infty"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial1(r,p) \\rightarrow Normal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/PascalNormal.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000868>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Normal 3 and Normal 1 whereby \\\\mu = \\\\mu, 
+\\\\sigma = 1 / \\\\sqrt{\\\\tau}""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000290> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """\\mu = \\mu, 
+\\sigma = 1 / \\sqrt{\\tau}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Normal3(\\mu,\\tau) \\rightarrow Normal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000232>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Inverse-Wishart 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Inverse-Wishart 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "InverseWishart1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000233> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000235> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000236> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "X"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "X(p \\times p) - \\text{positive-definite matrix}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000238> , <http://www.probonto.org/ontology#PROB_k0000237> .
+
+<http://www.probonto.org/ontology#PROB_k0000595>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "minimum of Standard-Uniform-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "minimum of Standard-Uniform-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StandardUniform1.minimum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "a=0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "minimum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "minimum"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001193>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Half Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Half Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "undefined"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000782>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Geometric 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Geometric 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Geometric1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000783> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000784> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0001175> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0001174> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000785> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000786> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000787> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000788> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              """k
+"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,1,2,3,\\dots\\}, \\text{ number of failures}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000789> .
+
+<http://www.probonto.org/ontology#PROB_k0000381>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Log-Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Log-Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\alpha"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000895>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 4 and Negative Binomial 3 whereby \\\\phi = r, \\\\mu = rp / 1 - p" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000161> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000135> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\phi = r, \\mu = rp / (1 - p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial4(r,p) \\rightarrow NegativeBinomial3(\\mu, \\phi)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000842>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Log-Normal 4 and Log-Normal 5 whereby \\\\mu = \\\\logm, 
+\\\\tau = 1 / \\\\logcv^2 + 1""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000500> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000526> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """\\mu = \\log(m), 
+\\tau = 1 / \\log(cv^2 + 1)"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal4(m,cv) \\rightarrow LogNormal5(\\mu,\\tau)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001152>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Two-Sided Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Two-Sided Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+\\frac{n (x-a)^{n-1}}{(b-a)(m-a)^{n-1}} \\text{ for } a < x < m \\\\
+\\frac{n (b-x)^{n-1}}{(b-a)(b-m)^{n-1}} \\text{ for } m \\leq x < b 
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """PDF1 = function(x,a,b,m,n) { (n*(x-a)^(n-1))/((b-a)*(m-a)^(n-1)) }
+PDF2 = function(x,a,b,m,n) { (n*(b-x)^(n-1))/((b-a)*(b-m)^(n-1)) }"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000581>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Log-Uniform 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Log-Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{x(\\log(max) - \\log(min))}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(x*(log(max) - log(min)))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001265>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Zeta 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Zeta 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\sum^x_{i=1} (1/i)^\\alpha}{\\zeta(\\alpha)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """Hfunc(x,alpha)/zeta(\\alpha)
+Hfunc = function(x,alpha) {
+  Hsum=array(0,length(x));
+  for(i in 1:length(x)) {
+    Hsum[i] = (1/i)^alpha
+  }
+  return(cumsum(Hsum))
+}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000445>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Exponential 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Exponential 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1 - \\exp(-x/\\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1 - exp(-x/beta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000107>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Negative Binomial 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Negative Binomial 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Sigma_{i=1}^x f(i), x \\in \\{0,1,2,...\\} \\text{ with } f \\text{ the PMF}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "cumsum(PMF)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000518>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Frechet 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Frechet 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\alpha}{\\sigma} \\Big(\\frac{x}{\\sigma}\\Big)^{-\\alpha-1} \\exp\\Big(-\\Big(\\frac{x}{\\sigma}\\Big)^{-\\alpha}\\Big)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "alpha/sigma * (x/sigma)^(-alpha-1) * exp(-(x/sigma)^(-alpha)) "^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001440>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Weibull Discrete 1 and Geometric 1 whereby \\\\text{The Geometric1p distribution is a special case of the WeibullDiscrete1} p, \\\\beta \\\\text{ distribution when } \\\\beta = 1." ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001176> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000782> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{The Geometric1(p) distribution is a special case of the WeibullDiscrete1} (p, \\beta) \\text{ distribution when } \\beta = 1."^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "WeibullDiscrete1(p\\beta) \\rightarrow Geometric1(p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/DiscreteweibullGeometric.pdf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000495>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of F 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of F 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "n_2/(n_2-2), n_2>2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001068>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 7 and Log-Normal 4 whereby m = \\\\mu_N/\\\\sqrt{1+\\\\sigma_N^2/\\\\mu_N^2}, cv = \\\\sigma_N/\\\\mu_N" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001028> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000500> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "m = \\mu_N/\\sqrt{1+\\sigma_N^2/\\mu_N^2}, cv = \\sigma_N/\\mu_N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal7(\\mu_N,\\sigma_N) \\rightarrow LogNormal4(m,cv)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000822>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Rice 1 and Exponential 1 whereby \\\\text{If } R \\\\sim Rice10,\\\\sigma \\\\text{ then } R^2 \\\\sim Exponential1\\\\lambda" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000487> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000418> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } R \\sim Rice1(0,\\sigma) \\text{ then } R^2 \\sim Exponential1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Rice1(\\nu,\\sigma) \\rightarrow Exponential1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/Rice_distribution}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000380>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Log-Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Log-Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\alpha \\pi/\\beta}{\\sin(\\pi/\\beta)} \\text{ if } \\beta>1, \\text{ else undefined}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000404>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Log-Logistic 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Log-Logistic 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{(\\lambda x)^\\kappa}{1+(\\lambda x)^\\kappa}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(lambda*x)^kappa / (1+(lambda*x)^kappa)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001208>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Makeham 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Makeham 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\text{mathematically intractable}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001111>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Arcsine 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Arcsine 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(b-a)^2/8"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000233>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Inverse-Wishart 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Inverse-Wishart 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\left|\\Psi\\right|^{\\frac{\\nu}{2}}}{2^{\\frac{\\nu p}{2}}\\Gamma_p(\\frac{\\nu}{2})} \\left|X\\right|^{-\\frac{\\nu+p+1}{2}}e^{-\\frac{1}{2}\\text{tr}(\\Psi X^{-1})}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000382>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Log-Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Log-Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\alpha \\Big(\\frac{\\beta-1}{\\beta+1}\\Big)^{1/\\beta} \\text{ if } \\beta>1, 0 \\text{ otherwise}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000894>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Exponential 1 and Exponential 2 whereby \\\\beta=1/\\\\lambda" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000418> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000443> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\beta=1/\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Exponential1(\\lambda) \\rightarrow Exponential2(\\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000596>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "maximum of Standard-Uniform-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "maximum of Standard-Uniform-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StandardUniform1.maximum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "b=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "maximum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "maximum"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001192>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Half Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Half Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\tan(\\pi/4)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000781>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "concentration of Von-Mises-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "concentration of Von-Mises-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "VonMises1.concentration"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\kappa"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\kappa \\in R^+"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "concentration"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "concentration"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000582>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Log-Uniform 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Log-Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\log(x) - \\log(min)}{\\log(max) - \\log(min)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(log(x) - log(min)) / (log(max) - log(min))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001151>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Two-Sided Power 1" , "TSP"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Two-Sided Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "TwoSidedPower1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001152> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001153> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0001155> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0001154> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001156> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001157> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (a,b)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001161> , <http://www.probonto.org/ontology#PROB_k0001158> , <http://www.probonto.org/ontology#PROB_k0001160> , <http://www.probonto.org/ontology#PROB_k0001159> .
+
+<http://www.probonto.org/ontology#PROB_k0001264>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Zeta 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Zeta 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{x^\\alpha \\zeta(\\alpha)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1 / (x^alpha * zeta(alpha))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000843>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Double Poisson 1 and Poisson 1 whereby \\\\phi=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000370> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000410> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\phi=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "DoublePoisson1(\\mu,\\phi) \\rightarrow Poisson1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{cameron2013regression}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000517>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Frechet 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Frechet 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Frechet1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000518> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000519> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000520> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000521> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000522> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000523> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in R^+"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000525> , <http://www.probonto.org/ontology#PROB_k0000524> .
+
+<http://www.probonto.org/ontology#PROB_k0000444>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Exponential 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Exponential 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1/\\beta e^{-x/\\beta}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/beta*exp(-1/beta*x)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001069>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 5 and Log-Normal 7 whereby \\\\mu_N = \\\\exp\\\\big\\\\mu + 1/2 \\\\tau\\\\big, \\\\sigma_N = \\\\exp\\\\big\\\\mu + 1/2 \\\\tau\\\\big \\\\sqrt{\\\\exp\\\\big1/\\\\tau\\\\big-1}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000526> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001028> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu_N = \\exp\\big(\\mu + 1/(2 \\tau)\\big), \\sigma_N = \\exp\\big(\\mu + 1/(2 \\tau)\\big) \\sqrt{\\exp\\big(1/\\tau\\big)-1}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal5(\\mu,\\tau) \\rightarrow LogNormal7(\\mu_N,\\sigma_N)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000108>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Negative Binomial 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Negative Binomial 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lambda"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000319>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Normal-inverse-gamma-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Normal-inverse-gamma-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NormalInverseGamma1.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in  R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000494>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of F 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of F 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "I_{\\frac{n_1 x}{n_1 x + n_2}} \\left(\\tfrac{n_1}{2}, \\tfrac{n_2}{2}\\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "Rbeta(n1*x / (n1*x + n2), n1/2, n2/2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000823>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label "relationship between Poisson 1 and Normal 1 whereby \\\\sigma^2 = \\\\lambda, \\\\mu = \\\\lambda, \\\\lambda \\\\rightarrow \\\\infty" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000410> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\sigma^2 = \\lambda, \\mu = \\lambda, \\lambda \\rightarrow \\infty"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Poisson1(\\lambda) \\rightarrow Normal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/PoissonNormal.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001441>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Student's t-distribution 2 and Student's t-distribution 3 whereby \\\\sigma=1/\\\\sqrt{\\\\tau}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000635> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001091> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\sigma=1/\\sqrt{\\tau}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StudentT2(\\mu,\\tau,k) \\rightarrow StudentT3(\\nu,\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001150>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degrees of freedom of Noncentral-F-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degrees of freedom of Noncentral-F-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NoncentralF1.degreesOfFreedom2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "n"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "n \\in N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degrees of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "degreesOfFreedom2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000405>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Log-Logistic 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Log-Logistic 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\pi}{\\kappa \\lambda \\sin(\\pi/\\kappa)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001112>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "lower bound of Arcsine-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "lower bound of Arcsine-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Arcsine2.lowerBound"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "a \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "lower bound"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "lowerBound"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001209>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Makeham 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Makeham 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\text{mathematically intractable}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000784>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Geometric 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Geometric 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1-(1 - p)^{k+1}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1-(1 - p)^(k+1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000383>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Log-Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Log-Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\alpha^2 \\Big(\\frac{2\\pi/\\beta}{\\sin(2\\pi/\\beta)} - \\frac{(\\pi/\\beta)^2}{\\sin^2(\\pi/\\beta)} \\Big), \\text{ for } \\beta>2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001191>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Half Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Half Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "undefined"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000597>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Gamma 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Gamma 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Gamma2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000598> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000599> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000600> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000601> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000602> , <http://www.probonto.org/ontology#PROB_k0000603> .
+
+<http://www.probonto.org/ontology#PROB_k0000443>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Negative exponential"^^<en> , "Exponential 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Exponential 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Exponential2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000444> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000445> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0000447> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0000446> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000448> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000449> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000450> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000451> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000452> .
+
+<http://www.probonto.org/ontology#PROB_k0000161>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Negative Binomial 4" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Negative Binomial 4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000162> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000163> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000164> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000165> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000166> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,1,2,3,\\dots\\} \\text{ -- number of successes}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000167> , <http://www.probonto.org/ontology#PROB_k0000168> .
+
+<http://www.probonto.org/ontology#PROB_k0000844>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Gamma 1 and Exponential 1 whereby k=1, \\\\theta=1/\\\\lambda" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000571> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000418> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "k=1, \\theta=1/\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Gamma1(k,\\theta) \\rightarrow Exponential1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{forbes2011statistical}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001267>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Zeta 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Zeta 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\zeta(\\alpha)\\zeta(\\alpha-2) - \\zeta(\\alpha-1)^2}{\\zeta(\\alpha)^2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000516>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scaling parameter of Scaled-Inverse-Chi-Square" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scaling parameter of Scaled-Inverse-Chi-Square"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ScaledInverseChiSquare1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma \\in R^+"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scaling parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000180>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Birnbaum-Saunders-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Birnbaum-Saunders-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "BirnbaumSaunders1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001154>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Two-Sided Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Two-Sided Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+-\\frac{n(x-a)^{n-1} (m-a)^{1-n}}{a-b+(m-a)(x-a)^n (m-a)^{-n}} &\\text{ for } a < x < m \\\\
+\\frac{n}{b-x} &\\text{ for } m \\leq x < b 
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """HF1 = function(x,a,b,m,n) { -(n*(x-a)^(n-1)*(m-a)^(1-n))/(a-b+(m-a)*(x-a)^n*(m-a)^(-n)) }
+HF2 = function(x,a,b,m,n) { n/(b-x) }
+"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000897>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label "relationship between Negative Binomial 1 and Poisson 1 whereby \\\\mu = np, n \\\\rightarrow \\\\infty" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000074> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000410> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = np, n \\rightarrow \\infty"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial1(r,p) \\rightarrow Poisson1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/PascalPoisson.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001066>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 7 and Log-Normal 3 whereby m = \\\\mu_N/\\\\sqrt{1+\\\\sigma_N^2/\\\\mu_N^2}, \\\\sigma = \\\\sqrt{\\\\log1+\\\\sigma_N^2/\\\\mu_N^2}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001028> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000478> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "m = \\mu_N/\\sqrt{1+\\sigma_N^2/\\mu_N^2}, \\sigma = \\sqrt{\\log(1+\\sigma_N^2/\\mu_N^2)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal7(\\mu_N,\\sigma_N) \\rightarrow LogNormal3(m,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000824>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Log-Normal 4 and Log-Normal 3 whereby m = m, 
+\\\\sigma = \\\\sqrt{\\\\logcv^2+1}""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000500> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000478> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """m = m, 
+\\sigma = \\sqrt{\\log(cv^2+1)}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal4(m,cv) \\rightarrow LogNormal3(m,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000160>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "probability of Inverse-Binomial-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "probability of Inverse-Binomial-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "InverseBinomial1.probability"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "1/2 < p < 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "probability"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "probability"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000109>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Negative Binomial 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Negative Binomial 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lambda (1 + \\tau \\lambda)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000497>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of F 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of F 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{2n_2^2(n_1+n_2-2)}{n_1(n_2-2)^2(n_2-4)}, n_2>4"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001113>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "upper bound of Arcsine-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "upper bound of Arcsine-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Arcsine2.upperBound"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "b \\in R, b > a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "upper bound"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "upperBound"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000402>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Fisk"^^<en> , "Log-Logistic 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Log-Logistic 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogLogistic2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000403> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000404> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0001078> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0001077> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000405> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000406> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000407> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000409> , <http://www.probonto.org/ontology#PROB_k0000408> .
+
+<http://www.probonto.org/ontology#PROB_k0000384>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Log-Logistic-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Log-Logistic-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogLogistic1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000783>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Geometric 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Geometric 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(1 - p)^k\\,p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "p*(1-p)^k"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000442>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "log Poisson intensity of Poisson-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "log Poisson intensity of Poisson-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Poisson2.logRate"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "log Poisson intensity"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "logRate"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001190>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Half Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Half Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1 - \\frac2\\pi \\arctan(x)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1 - 2/pi * atan(x)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000235>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Inverse-Wishart 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Inverse-Wishart 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\Psi}{\\nu - p - 1} \\text{ for }\\nu > p + 1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000845>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 5 and Negative Binomial 3 whereby \\\\mu = \\\\alpha / \\\\beta, \\\\phi = \\\\alpha" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000190> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000135> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = \\alpha / \\beta, \\phi = \\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial5(\\alpha, \\beta) \\rightarrow NegativeBinomial3(\\mu, \\phi)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001266>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Zeta 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Zeta 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\zeta(\\alpha-1)/\\zeta(\\alpha)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000515>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degrees of freedom of Scaled-Inverse-Chi-Square" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degrees of freedom of Scaled-Inverse-Chi-Square"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ScaledInverseChiSquare1.degreesOfFreedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\nu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\nu \\in R^+"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degrees of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "degreesOfFreedom"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000162>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Negative Binomial 4" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Negative Binomial 4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\binom {k+r-1}k (1-p)^r p^k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "choose(k+r-1,k) * (1-p)^r * p^k"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000181>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Birnbaum-Saunders-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Birnbaum-Saunders-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "BirnbaumSaunders1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\gamma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\gamma > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001153>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Two-Sided Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Two-Sided Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+\\frac{(x-a)^n (m-a)^{1-n}}{b-a} \\text{ for } a < x < m \\\\
+-\\frac{a+b(b-x)^n (b-m)^{-n} - b-m(b-x)^n (b-m)^{-n}}{b-a} \\text{ for } m \\leq x < b 
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """CDF1 = function(x,a,b,m,n) { ((x-a)^n*(m-a)^(1-n))/(b-a) }
+CDF2 = function(x,a,b,m,n) { -(a+b*(b-x)^n*(b-m)^(-n)-b-m*(b-x)^n*(b-m)^(-n))/(b-a) }"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000580>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Log-Uniform 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Log-Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogUniform1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000581> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000582> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000583> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000584> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (min,max)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000586> , <http://www.probonto.org/ontology#PROB_k0000585> .
+
+<http://www.probonto.org/ontology#PROB_k0000598>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Gamma 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Gamma 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\mu^r x^{r-1} e^{-\\mu x}}{\\Gamma(r)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(mu^r * x^(r-1) * exp(-mu*x)) / gamma(r)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000896>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label "relationship between Gamma 1 and Normal 1 whereby \\\\mu = k \\\\theta, \\\\sigma^2 = k^2 \\\\theta, \\\\theta \\\\rightarrow \\\\infty " ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000571> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = k \\theta, \\sigma^2 = k^2 \\theta, \\theta \\rightarrow \\infty "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Gamma1(k,theta) \\rightarrow Normal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/GammaNormal1.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000825>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Generalized Poisson 3 and Poisson 1 whereby \\\\alpha = 0, \\\\lambda=\\\\mu" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000758> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000410> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\alpha = 0, \\lambda=\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "GeneralizedPoisson3(\\mu,\\alpha) \\rightarrow Poisson1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{hilbe2011negative} \\\\ 
+\\cite{famoye2006zero}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001067>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 4 and Log-Normal 7 whereby \\\\mu_N = m \\\\sqrt{cv^2 + 1}, \\\\sigma_N = m \\\\;cv\\\\,\\\\sqrt{cv^2 + 1}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000500> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001028> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu_N = m \\sqrt{cv^2 + 1}, \\sigma_N = m \\;cv\\,\\sqrt{cv^2 + 1}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal4(m,cv) \\rightarrow LogNormal7(\\mu_N,\\sigma_N)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000317>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Normal-inverse-gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Normal-inverse-gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac {\\sqrt{\\lambda}} {\\sigma\\sqrt{2\\pi} }  \\frac{\\beta^\\alpha}{\\Gamma(\\alpha)} \\, \\left( \\frac{1}{\\sigma^2} \\right)^{\\alpha + 1}   e^{ -\\frac { 2\\beta + \\lambda(x - \\mu)^2} {2\\sigma^2}  } "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "sqrt(lambda)/(sigma*sqrt(2*pi)) * beta^alpha/gamma(alpha) * (1/sigma^2)^(alpha + 1) * exp(- (2*beta+lambda*(x-mu)^2)/(2*sigma^2))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000496>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of F 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of F 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{n_2(n_1-2)}{n_1(n_2+2)}, n_1>2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000403>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Log-Logistic 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Log-Logistic 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\lambda \\kappa(\\lambda x)^{\\kappa-1}}{(1+(\\lambda x)^\\kappa)^2}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(lambda*kappa*(lambda*x)^(kappa-1)) / (1+(lambda*x)^kappa)^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001114>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Noncentral Beta 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Noncentral Beta 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NoncentralBeta1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001115> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001116> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [0,1]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001118> , <http://www.probonto.org/ontology#PROB_k0001117> , <http://www.probonto.org/ontology#PROB_k0001119> .
+
+<http://www.probonto.org/ontology#PROB_k0000599>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Gamma 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Gamma 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\Gamma(r)} \\gamma\\left(r, \\mu x\\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/gamma(r) * Igamma(r,mu*x,lower=T)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000182>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Inverse-Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Inverse-Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "InverseGamma1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000183> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000184> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000185> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000186> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000187> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000188> , <http://www.probonto.org/ontology#PROB_k0000189> .
+
+<http://www.probonto.org/ontology#PROB_k0000490>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "noncentrality parameter of Rice-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "noncentrality parameter of Rice-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Rice1.noncentrality"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\nu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\nu \\geq 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "noncentrality parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "noncentrality"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000066>
+      a       owl:Class ;
+      rdfs:label "Transformation" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000063> .
+
+<http://www.probonto.org/ontology#PROB_k0000899>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Exponential 2 and Exponential 1 whereby \\\\lambda=1/\\\\beta" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000443> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000418> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\lambda=1/\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Exponential2(\\beta) \\rightarrow Exponential1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001044>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Trapezoidal 1" , "Piecewise Random"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Trapezoidal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Trapezoidal1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001045> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001081> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001047> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001048> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [a,d]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001052> , <http://www.probonto.org/ontology#PROB_k0001049> , <http://www.probonto.org/ontology#PROB_k0001051> , <http://www.probonto.org/ontology#PROB_k0001050> .
+
+<http://www.probonto.org/ontology#PROB_k0000846>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Gamma 1 and Inverse-Gamma 1 whereby \\\\text{If } X \\\\sim Gamma1\\\\alpha,\\\\beta \\\\text{ then } X^{-1} \\\\sim InverseGamma1\\\\alpha,\\\\beta^{-1}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000571> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000182> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X \\sim Gamma1(\\alpha,\\beta) \\text{ then } X^{-1} \\sim InverseGamma1(\\alpha,\\beta^{-1})"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Gamma1(\\alpha,\\beta) \\rightarrow InverseGamma1(\\alpha,\\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/Inverse-gamma_distribution}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000236>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Inverse-Wishart 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Inverse-Wishart 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\Psi}{\\nu + p + 1}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000471>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Exponentially modified Gaussian 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Exponentially modified Gaussian 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\lambda}{2} e^{\\frac{\\lambda}{2} (2 \\mu + \\lambda \\sigma^2 - 2 x)} \\mbox{erfc} (\\frac{\\mu + \\lambda \\sigma^2 - x}{ \\sqrt{2} \\sigma}) "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """lambda/2*exp(lambda/2*(2*mu+lambda*sigma^2-2*x))*erfc((mu+lambda*sigma^2-x)/(sqrt(2)*sigma)) \\\\
+erfc <- function(x) 2 * pnorm(x * sqrt(2), lower = FALSE)"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000441>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Poisson 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Poisson 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\exp(\\alpha)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001269>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Dagum 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Dagum 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Dagum1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001270> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001271> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001272> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0001273> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0001274> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001275> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001278> , <http://www.probonto.org/ontology#PROB_k0001277> , <http://www.probonto.org/ontology#PROB_k0001276> .
+
+<http://www.probonto.org/ontology#PROB_k0000385>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Log-Logistic-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Log-Logistic-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogLogistic1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000611>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Lomax-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Lomax-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Lomax1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\lambda > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000217>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Negative Binomial 6" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Negative Binomial 6"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial6"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000218> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000220> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000221> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000222> , <http://www.probonto.org/ontology#PROB_k0000223> .
+
+<http://www.probonto.org/ontology#PROB_c0000040>
+      a       owl:ObjectProperty ;
+      rdfs:label "distribution has SF" .
+
+<http://www.probonto.org/ontology#PROB_k0000909>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Frechet 2 and Frechet 1 whereby m=0" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000543> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000517> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "m=0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Frechet2(\\alpha,\\sigma,m) \\rightarrow Frechet1(\\alpha,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.mathwave.com/help/easyfit/html/analyses/distributions/frechet.html}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000256>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Double Exponential 1"^^<en> , "Laplace 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Laplace 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Laplace1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000257> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000258> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000259> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000260> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000261> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000262> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000263> , <http://www.probonto.org/ontology#PROB_k0000264> .
+
+<http://www.probonto.org/ontology#PROB_k0000421>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Exponential 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Exponential 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "lambda"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000400>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Erlang-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Erlang-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Erlang1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "b>0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000959>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Normal 1 and Logit Normal 1 whereby \\\\text{ If } Y \\\\text{ is a random variable with a normal distribution, and } P \\\\text{ is the logistic function, then } \\\\\\\\ X = PY \\\\text{ has a logit-normal distribution}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000352> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{ If } Y \\text{ is a random variable with a normal distribution, and } P \\text{ is the logistic function, then } \\\\ X = P(Y) \\text{ has a logit-normal distribution}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Normal1(\\mu,\\sigma) \\rightarrow LogitNormal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/Logit-normal_distribution}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000316>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Normal-inverse-gamma 1" , "Gaussian- inverse-gamma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Normal-inverse-gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NormalInverseGamma1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000317> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty), \\sigma^2 \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000319> , <http://www.probonto.org/ontology#PROB_k0000322> , <http://www.probonto.org/ontology#PROB_k0000321> , <http://www.probonto.org/ontology#PROB_k0000320> .
+
+<http://www.probonto.org/ontology#PROB_k0000296>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Normal 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1/\\tau"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000183>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Inverse-Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Inverse-Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\beta^\\alpha}{\\Gamma(\\alpha)} x^{-\\alpha - 1} \\exp \\left(\\frac{-\\beta}{x}\\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "beta^alpha/gamma(alpha) * x^(-alpha-1) * exp(-beta/x)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000491>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale parameter of Rice-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale parameter of Rice-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Rice1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001064>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 7 and Log-Normal 2 whereby \\\\mu = \\\\log\\\\Big \\\\mu_N/\\\\sqrt{1+\\\\sigma_N^2/\\\\mu_N^2} \\\\Big, v = \\\\log1+\\\\sigma_N^2/\\\\mu_N^2" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001028> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000453> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = \\log\\Big( \\mu_N/\\sqrt{1+\\sigma_N^2/\\mu_N^2} \\Big), v = \\log(1+\\sigma_N^2/\\mu_N^2)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal7(\\mu_N,\\sigma_N) \\rightarrow LogNormal2(\\mu,v)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001289>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Zipf 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Zipf 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "H_{n,\\alpha-1}/ H_{n,\\alpha}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000898>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Generalized Gamma 3 and Generalized Gamma 1 whereby a=1/\\\\mu, d=\\\\beta r, p=\\\\beta" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000670> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000621> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "a=1/\\mu, d=\\beta r, p=\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "GeneralizedGamma3(r,\\mu,\\beta) \\rightarrow GeneralizedGamma1(a,d,p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001045>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Trapezoidal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Trapezoidal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\left\\{ \\begin{array}{rcl}  
+\\dfrac{2}{d+c-a-b}\\dfrac{x-a}{b-a} & a\\leq x < b & \\\\
+\\dfrac{2}{d+c-a-b} & b\\leq x < c \\\\ 
+\\dfrac{2}{d+c-a-b}\\dfrac{d-x}{d-c} & c\\leq x \\leq d 
+\\end{array}\\right. \\nonumber \\\\"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """PMF1 = 2/(d+c-a-b)*(x-a)/(b-a)
+PMF2 = 2/(d+c-a-b)
+PMF3 = 2/(d+c-a-b)*(d-x)/(d-c) """^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000067>
+      a       owl:Class ;
+      rdfs:label "Transformation, Limiting" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000063> .
+
+<http://www.probonto.org/ontology#PROB_k0001268>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Zeta-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Zeta-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Zeta1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha \\in R, \\alpha > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000847>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label "relationship between Hypergeometric 1 and Binomial 1 whereby p = K/N, n=n, N \\\\rightarrow \\\\infty" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000126> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000117> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "p = K/N, n=n, N \\rightarrow \\infty"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Hypergeometric1(N,K,n) \\rightarrow Binomial1(n,p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/HypergeometricBinomial.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000470>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "ExGaussian"^^<en> , "Exponentially modified Gaussian 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Exponentially modified Gaussian 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ExponentiallyModifiedGaussian1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000471> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000472> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000473> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000474> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000476> , <http://www.probonto.org/ontology#PROB_k0000475> , <http://www.probonto.org/ontology#PROB_k0000477> .
+
+<http://www.probonto.org/ontology#PROB_k0000237>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale matrix of Inverse-Wishart-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale matrix of Inverse-Wishart-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "InverseWishart1.scaleMatrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\Psi"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\Psi > 0, \\text{positive-definite matrix}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale matrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scaleMatrix"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000386>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Pareto Type II" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Pareto Type II"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ParetoTypeII1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000387> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000388> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [\\mu, +\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000389> , <http://www.probonto.org/ontology#PROB_k0000391> , <http://www.probonto.org/ontology#PROB_k0000390> .
+
+<http://www.probonto.org/ontology#PROB_k0000610>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Lomax 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Lomax 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """{{\\lambda^2 \\alpha} \\over {(\\alpha-1)^2(\\alpha-2)}} \\text{ for } \\alpha > 2;\\\\
+\\infty \\text{ for } 1 < \\alpha \\le 2; \\\\
+\\text{Otherwise undefined}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000440>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Poisson 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Poisson 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\exp(\\alpha)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000041>
+      a       owl:ObjectProperty ;
+      rdfs:label "distribution has HF" .
+
+<http://www.probonto.org/ontology#PROB_k0000216>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Inverse-Gaussian-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Inverse-Gaussian-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "InverseGaussian1.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000420>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Exponential 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Exponential 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1 - \\exp(-\\lambda x)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1 - exp(-lambda*x)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000401>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Erlang-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Erlang-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Erlang1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "c"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "c>0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000297>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Normal-3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Normal-3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Normal3.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000257>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Laplace 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Laplace 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{2\\,b} \\exp \\left(-\\frac{|x-\\mu|}b \\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(2*b) * exp(- abs(x-mu)/b )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001288>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Zipf 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Zipf 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """H_{x,\\alpha}/H_{n,\\alpha}, \\text{ with } x=1,2,...,n\\\\
+Hfunc = function(n,alpha) {
+  Hsum=0;
+  for(i in 1:n) {
+    Hsum = Hsum + (1/i)^alpha
+  }
+  return(Hsum)
+}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """CDF = function(x,n,alpha) { 
+  H=array(0,length(x));
+  for(j in 1:length(x)) {
+    H[j] = Hfunc(x[j],alpha) / Hfunc(n,alpha) 
+  }
+  cat(H)
+  return(H)
+}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000315>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Logistic-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Logistic-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Logistic1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "s"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "s > 0, s \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001065>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 3 and Log-Normal 7 whereby \\\\mu_N = m\\\\;\\\\exp\\\\sigma^2/2, \\\\sigma_N = m \\\\;\\\\exp\\\\sigma^2/2\\\\sqrt{\\\\exp\\\\sigma^2-1}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000478> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001028> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu_N = m\\;\\exp(\\sigma^2/2), \\sigma_N = m \\;\\exp(\\sigma^2/2)\\sqrt{\\exp(\\sigma^2)-1}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal3(m,\\sigma) \\rightarrow LogNormal7(\\mu_N,\\sigma_N)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000184>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Inverse-Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Inverse-Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\Gamma(\\alpha, \\beta/x)}{\\Gamma(\\alpha)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "Igamma(alpha, beta/x, lower=F) / gamma(alpha)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000238>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degrees of freedom of Inverse-Wishart-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degrees of freedom of Inverse-Wishart-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "InverseWishart1.degreesOfFreedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\nu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\nu > p-1, \\nu \\in  R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degrees of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "degreesOfFreedom"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000068>
+      a       owl:Class ;
+      rdfs:label "Limiting, Special case" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000063> .
+
+<http://www.probonto.org/ontology#PROB_k0001061>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 7 and Log-Normal 1 whereby \\\\mu = \\\\log\\\\Big\\\\mu_N/\\\\sqrt{1+\\\\sigma_N^2/\\\\mu_N^2}\\\\Big, \\\\sigma = \\\\sqrt{\\\\log1+\\\\sigma_N^2/\\\\mu_N^2}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001028> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000428> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = \\log\\Big(\\mu_N/\\sqrt{1+\\sigma_N^2/\\mu_N^2}\\Big), \\sigma = \\sqrt{\\log(1+\\sigma_N^2/\\mu_N^2)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal7(\\mu_N,\\sigma_N) \\rightarrow LogNormal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000473>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Exponentially modified Gaussian 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Exponentially modified Gaussian 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu + 1/\\lambda"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000907>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Logistic 1 and Logistic 2 whereby \\\\tau=1/s" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000307> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000331> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\tau=1/s"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Logistic1(\\mu,s) \\rightarrow Logistic2(\\mu,\\tau)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000387>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Pareto Type II" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Pareto Type II"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "{\\alpha \\over \\lambda} \\left[{1+ {x-\\mu \\over \\lambda}}\\right]^{-(\\alpha+1)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "alpha/lambda* (1+ (x-mu)/lambda)^(-(alpha+1))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000780>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Von-Mises-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Von-Mises-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "VonMises1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000760>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Generalized Poisson 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Generalized Poisson 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Sigma_{i=1}^x f(i), x \\in \\{0,1,2,...\\} \\text{ with } f \\text{ the PMF}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "cumsum(PMF)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000314>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Logistic-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Logistic-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Logistic1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000493>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of F 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of F 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\Gamma(\\frac{n_1 + n_2}{2}) (\\frac{n_1}{n_2})^{n_1/2} x^{n_1/2-1}}{\\Gamma(\\frac{n_1}{2})\\Gamma(\\frac{n_2}{2})\\big[\\frac{n_1}{n_2}x+1\\big]^{(n_1+n_2)/2}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "gamma((n1 + n2)/2)*(n1/n2)^(n1/2)*x^(n1/2-1)/(gamma(n1/2)*gamma(n2/2)*(n1/n2*x+1)^((n1+n2)/2))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000185>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Inverse-Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Inverse-Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\beta}{\\alpha-1} \\text{ for } \\alpha > 1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000258>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Laplace 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Laplace 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+      \\frac12 \\exp \\left( \\frac{x-\\mu}{b} \\right) & \\mbox{if }x < \\mu \\\\
+          1-\\frac12 \\exp \\left( -\\frac{x-\\mu}{b} \\right) & \\mbox{if }x \\geq \\mu
+       \\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """1/2 * exp( (x-mu)/b ) # for x < mu
+1- 1/2 * exp( -(x-mu)/b ) # x >= mu"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000820>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Generalized Gamma 2 and Gamma 1 whereby k=1, a=0 \\\\text{ and renaming parameters: } c=k, b=\\\\theta" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000644> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000571> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "k=1, a=0 \\text{ and renaming parameters: } c=k, b=\\theta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "GeneralizedGamma2(a,b,c,k) \\rightarrow Gamma1(k,\\theta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{forbes2011statistical}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000848>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Log-Normal 5 and Log-Normal 4 whereby m = \\\\exp\\\\mu, 
+cv = \\\\sqrt{\\\\exp1/\\\\tau - 1}""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000526> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000500> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """m = \\exp(\\mu), 
+cv = \\sqrt{\\exp(1/\\tau) - 1}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal5(\\mu,\\tau) \\rightarrow LogNormal4(m,cv)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000298>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "precision of Normal-3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "precision of Normal-3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Normal3.precision"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\tau"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\tau>0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "precision"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "precision"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001130>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Noncentral chi-squared 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Noncentral chi-squared 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\delta + n"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000472>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Exponentially modified Gaussian 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Exponentially modified Gaussian 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\Phi(u, 0, v) - e^{-u + v^2/2+ \\log(\\Phi(u, v^2, v))} \\text{ with }
+u = \\lambda(x - \\mu) \\text{ and } v = \\lambda \\sigma"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """CDF = function(x,mu,sigma,lambda) {
+  u = lambda * (x - mu); v = lambda * sigma;
+  CDF_Normal1(u, 0, v) - exp(-u + v^2/2 + log(CDF_Normal1(u, v^2, v)))};
+CDF_Normal1 = function(x,mu,sigma) {  1/2 * (1 + erf((x-mu)/(sigma*sqrt(2)))) }"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000239>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Normal"^^<en> , "Gaussian"^^<en> , "Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Normal1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000240> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000241> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000242> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000243> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000244> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000245> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000247> , <http://www.probonto.org/ontology#PROB_k0000246> .
+
+<http://www.probonto.org/ontology#PROB_c0000069>
+      a       owl:Class ;
+      rdfs:label "Special case, Limiting" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000063> .
+
+<http://www.probonto.org/ontology#PROB_k0001062>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 2 and Log-Normal 7 whereby \\\\mu_N = \\\\exp\\\\mu+v/2, \\\\sigma_N = \\\\exp\\\\mu+v/2\\\\sqrt{\\\\expv-1}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000453> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001028> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu_N = \\exp(\\mu+v/2), \\sigma_N = \\exp(\\mu+v/2)\\sqrt{\\exp(v)-1}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal2(\\mu,v) \\rightarrow LogNormal7(\\mu_N,\\sigma_N)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000908>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Erlang 1 and Exponential 2 whereby c=1, b=\\\\beta" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000392> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000443> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "c=1, b=\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Erlang1(b,c) \\rightarrow Exponential2(\\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{forbes2011statistical}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000218>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Negative Binomial 6" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Negative Binomial 6"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\binom {k+\\phi-1}k \\Big(\\frac{\\exp(\\eta)}{\\exp(\\eta) + \\phi} \\Big)^{k} \\Big(\\frac{\\phi}{\\phi + \\exp(\\eta)} \\Big)^{\\phi}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "choose(k+phi-1,k) * (exp(eta) / (exp(eta) + phi))^k * (phi / (phi + exp(eta)))^phi"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000388>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Pareto Type II" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Pareto Type II"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1- \\left[{1+ {x-\\mu \\over \\lambda}}\\right]^{-\\alpha}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1- (1+ (x-mu)/lambda)^(-alpha)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001110>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Arcsine 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Arcsine 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "x \\in \\{a,b\\}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000313>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{s^2 \\pi^2}{3}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000539>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Skew Normal" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Skew Normal"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sigma^2\\left(1 - \\frac{2\\delta^2}{\\pi}\\right) \\text{ where } \\delta = \\frac{\\alpha}{\\sqrt{1+\\alpha^2}}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001063>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Standard Uniform 1 and Pareto Type I whereby x_m X^{-1/\\\\alpha}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000587> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000361> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "x_m X^{-1/\\alpha}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StandardUniform1(0,1) \\rightarrow ParetoTypeI1(x_m,\\alpha)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/StandarduniformPareto.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000186>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Inverse-Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Inverse-Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\beta}{\\alpha + 1}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000259>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Laplace 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Laplace 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000492>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "F 1" , "Fisher-Snedecor"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "F 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "F1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000493> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000494> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000495> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000496> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000497> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000498> , <http://www.probonto.org/ontology#PROB_k0000499> .
+
+<http://www.probonto.org/ontology#PROB_k0000849>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Zero-inflated Poisson 1 and Poisson 1 whereby \\\\pi=0" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000197> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000410> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\pi=0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "ZeroInflatedPoisson1(\\lambda,\\pi) \\rightarrow Poisson1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{Troconiz:2009fv}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000519>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Frechet 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Frechet 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\exp\\Big(-\\Big(\\frac{\\sigma}{x}\\Big)^\\alpha\\Big)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp(-(sigma/x)^alpha)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000299>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Chi-square"^^<en> , "Chi-squared 1" , "Chi square"^^<en> , "Chisquare"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Chi-squared 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ChiSquared1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000300> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000301> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000302> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000303> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000304> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000305> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000306> .
+
+<http://www.probonto.org/ontology#PROB_k0000821>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Conway-Maxwell-Poisson 1 and Binomial 1 whereby \\\\text{For } \\\\nu=\\\\infty \\\\text{  the distribution of the sum is binomial with parameters } \\\\\\\\ n \\\\text{ and } \\\\lambda/1+\\\\lambda" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000323> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000117> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{For } \\nu=\\infty \\text{  the distribution of the sum is binomial with parameters } \\\\ n \\text{ and } \\lambda/(1+\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "ConwayMaxwellPoisson1(\\lambda,\\nu) \\rightarrow Binomial1(p) "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{shmueli2005useful}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000550>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Frechet-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Frechet-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Frechet2.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha \\in (0, \\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000537>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Skew Normal" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Skew Normal"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Phi\\Big(\\frac{x-\\mu}{\\sigma}\\Big) - 2 T\\Big(\\frac{x-\\mu}{\\sigma},\\alpha\\Big)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "Phi((x-mu)/sigma) - 2*T.Owen((x-mu)/sigma,alpha)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001416>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label "relationship between Zipf 1 and Zeta 1 whereby \\\\text{The limiting distribution of a } Zipf1\\\\alpha, n \\\\text{ random variable as }\\\\\\\\ n\\\\rightarrow \\\\infty \\\\text{ is the } Zeta1\\\\alpha \\\\text{ distribution.}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001286> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001263> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{The limiting distribution of a } Zipf1(\\alpha, n) \\text{ random variable as }\\\\ n\\rightarrow \\infty \\text{ is the } Zeta1(\\alpha) \\text{ distribution.}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Zipf1(\\alpha,n) \\rightarrow Zeta1(\\alpha)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/ZipfZeta.pdf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001108>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Arcsine 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Arcsine 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(a+b)/2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001172>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Beta-Negative-Binomial1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Beta-Negative-Binomial1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "BetaNegativeBinomial1.shape2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000337>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Logistic 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Logistic 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\pi^2}{3\\tau^2 }"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001437>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Student's t-distribution 3 and Student's t-distribution 1 whereby \\\\mu=0, \\\\sigma=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001091> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000613> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu=0, \\sigma=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StudentT3(\\nu,\\mu,\\sigma) \\rightarrow StudentT1(\\nu)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000083>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has R code expression" .
+
+<http://www.probonto.org/ontology#PROB_c0000025>
+      a       owl:Class ;
+      rdfs:label "cumulative density function" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000017> .
+
+<http://www.probonto.org/ontology#PROB_k0000265>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Normal"^^<en> , "Gaussian"^^<en> , "Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Normal2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000266> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000267> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000268> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000269> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000270> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000271> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000273> , <http://www.probonto.org/ontology#PROB_k0000272> .
+
+<http://www.probonto.org/ontology#PROB_k0000938>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Chi-squared 1 and F 1 whereby \\\\text{If } X_1 \\\\sim ChiSquared1n_1, X_2 \\\\sim ChiSquared1n_2 \\\\text{ are independent random variables }\\\\\\\\ \\\\Rightarrow \\\\frac{X_1/n_1}{X_2/n_2} \\\\sim F1n_1,n_2" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000299> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000492> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X_1 \\sim ChiSquared1(n_1), X_2 \\sim ChiSquared1(n_2) \\text{ are independent random variables }\\\\ \\Rightarrow \\frac{X_1/n_1}{X_2/n_2} \\sim F1(n_1,n_2)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "ChiSquared1(n) \\rightarrow F1(n_1,n_2)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/ChisquareF.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000662>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Triangular 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Triangular 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+2(x-a) / [(b-a)(c-a)] & \\text{ for } a \\leq x \\leq c \\\\
+2(b-x) / [(b-a)(b-c)] & \\text{ for } c \\leq x \\leq b
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """2*(x-a) / ((b-a)*(c-a)) for a <= x <= c \\\\
+2*(b-x) / ((b-a)*(b-c)) for c <= x <= b """^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000918>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 1 and Negative Binomial 3 whereby \\\\phi=r, \\\\mu=r1-p/p" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000074> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000135> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\phi=r, \\mu=r(1-p)/p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial1(r, p) \\rightarrow NegativeBinomial3(\\mu, \\phi)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000614>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Student's t-distribution 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Student's t-distribution 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\Gamma \\left(\\frac{\\nu+1}{2} \\right)} {\\sqrt{\\nu\\pi}\\,\\Gamma \\left(\\frac{\\nu}{2} \\right)} \\left(1+\\frac{x^2}{\\nu} \\right)^{-\\frac{\\nu+1}{2}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "gamma((nu+1)/2)/(sqrt(nu*pi)*gamma(nu/2))*(1+x^2/nu)^(-(nu+1)/2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001173>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "number of successes of Beta-Negative-Binomial1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "number of successes of Beta-Negative-Binomial1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "BetaNegativeBinomial1.numberOfSuccesses"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "n"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "n \\in N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "number of successes"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "numberOfSuccesses"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001384>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Standard-Two-Sided-Power-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Standard-Two-Sided-Power-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StandardTwoSidedPower1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "m"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "a < m < b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000045>
+      a       owl:ObjectProperty ;
+      rdfs:label "distribution has variance" .
+
+<http://www.probonto.org/ontology#PROB_k0000578>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Gamma-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Gamma-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Gamma1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "k > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000063>
+      a       owl:Class ;
+      rdfs:label "relationship between distributions" .
+
+<http://www.probonto.org/ontology#PROB_c0000004>
+      a       owl:Class ;
+      rdfs:label "number" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000005> .
+
+<http://www.probonto.org/ontology#PROB_k0000378>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Log-Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Log-Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{(\\beta/\\alpha)(x/\\alpha)^{\\beta-1}}{(1+(x/\\alpha)^\\beta)^2}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(beta/alpha)*(x/alpha)^(beta-1) / (1+(x/alpha)^beta)^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000462>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Rayleigh 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Rayleigh 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Rayleigh1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000463> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000464> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000465> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000466> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000467> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000468> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000469> .
+
+<http://www.probonto.org/ontology#PROB_k0001060>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 1 and Log-Normal 7 whereby \\\\mu_N = \\\\exp\\\\Big\\\\mu + \\\\frac12 \\\\sigma^2\\\\Big, \\\\sigma_N = \\\\exp\\\\big\\\\mu + \\\\frac{1}{2}\\\\sigma^2\\\\big\\\\sqrt{\\\\exp\\\\sigma^2-1}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000428> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001028> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu_N = \\exp\\Big(\\mu + \\frac12 \\sigma^2\\Big), \\sigma_N = \\exp\\big(\\mu + \\frac{1}{2}\\sigma^2\\big)\\sqrt{\\exp(\\sigma^2)-1}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal1(\\mu,\\sigma) \\rightarrow LogNormal7(\\mu_N,\\sigma_N)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001417>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Triangular 1 and Standard Triangular 1 whereby StandardTriangular1 \\\\text{ distribution is a special case of the } Triangular1a,b,c \\\\text{ distribution } \\\\\\\\ \\\\text{ when } a = -1, b = 1, c = 0." ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000661> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001370> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "StandardTriangular1 \\text{ distribution is a special case of the } Triangular1(a,b,c) \\text{ distribution } \\\\ \\text{ when } a = -1, b = 1, c = 0."^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Triangular1(a,b,c)  \\rightarrow StandardTriangular1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/TriangularStandardtriangular.pdf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000538>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Skew Normal" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Skew Normal"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu + \\sigma\\delta\\sqrt{\\frac{2}{\\pi}} \\text{ where } \\delta = \\frac{\\alpha}{\\sqrt{1+\\alpha^2}}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001107>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Arcsine 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Arcsine 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{2}{\\pi}\\arcsin\\left(\\sqrt \\frac{x-a}{b-a} \\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "2/pi*asin(sqrt((x-a)/(b-a)))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000338>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Logistic-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Logistic-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Logistic2.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000264>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Laplace-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Laplace-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Laplace1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "b > 0, b \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000024>
+      a       owl:Class ;
+      rdfs:label "probability mass function" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000017> .
+
+<http://www.probonto.org/ontology#PROB_c0000082>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has abbreviation" .
+
+<http://www.probonto.org/ontology#PROB_k0000937>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 2 and Negative Binomial 1 whereby r=1/\\\\tau, p = 1/1+\\\\tau \\\\lambda" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000105> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000074> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "r=1/\\tau, p = 1/(1+\\tau \\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial2(\\lambda, \\tau) \\rightarrow NegativeBinomial1(r, p) "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001436>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Normal 1 and Maxwell Boltzmann 1 whereby \\\\text{If } U_1, U_2, U_3 \\\\text{ are independent normal variables with mean} 0 \\\\text{ and standard deviation } \\\\sigma > 0 \\\\text{ then } X = \\\\sqrt{U_1^2 +U_3^2 +U_3^2} \\\\text{ has the Maxwell distribution with scale parameter } \\\\sigma" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001223> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } U_1, U_2, U_3 \\text{ are independent normal variables with mean} 0 \\text{ and standard deviation } \\sigma > 0 \\text{ then } X = \\sqrt{U_1^2 +U_3^2 +U_3^2} \\text{ has the Maxwell distribution with scale parameter } \\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Normal1(\\mu, \\sigma) \\rightarrow MaxwellBoltzmann1(\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.math.uah.edu/stat/special/Maxwell.html}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000615>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Student's t-distribution 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Student's t-distribution 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{2} + x \\Gamma \\left( \\frac{\\nu+1}{2} \\right)  \\times \\frac{\\,_2F_1 \\left ( \\frac{1}{2},\\frac{\\nu+1}{2};\\frac{3}{2}; -\\frac{x^2}{\\nu} \\right)} {\\sqrt{\\pi\\nu}\\,\\Gamma \\left(\\frac{\\nu}{2}\\right)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/2+x*gamma((nu+1)/2)*hypergeo(1/2,(nu+1)/2,3/2,-x^2/nu)/( sqrt(pi*nu) *gamma(nu/2))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000663>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Triangular 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Triangular 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+(x-a)^2 / [(b-a)(c-a)] & \\text{ for } a \\leq x \\leq c \\\\
+1 - (b-x)^2 / [(b-a)(b-c)] & \\text{ for } c \\leq x \\leq b
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """(x-a)^2 / ((b-a)*(c-a)) for a <= x <= c \\\\
+1 - (b-x)^2 / ((b-a)*(b-c)) for c <= x <= b """^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000917>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Student's t-distribution 2 and Student's t-distribution 1 whereby \\\\mu=0, \\\\tau=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000635> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000613> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu=0, \\tau=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StudentT2(\\mu,\\tau,k) \\rightarrow StudentT1(\\nu)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001174>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Geometric 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Geometric 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "p"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000044>
+      a       owl:ObjectProperty ;
+      rdfs:label "distribution has mode" .
+
+<http://www.probonto.org/ontology#PROB_k0000377>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Log-Logistic 1" , "Fisk"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Log-Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogLogistic1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000378> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000379> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000380> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000381> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000382> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000383> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000384> , <http://www.probonto.org/ontology#PROB_k0000385> .
+
+<http://www.probonto.org/ontology#PROB_k0000577>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "k \\theta^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001383>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Standard Two-Sided Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Standard Two-Sided Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{n-2(n-1)m(1-m)}{(n+2)(n+1)^2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000005>
+      a       owl:Class ;
+      rdfs:label "mathematical object" .
+
+<http://www.probonto.org/ontology#PROB_c0000062>
+      a       owl:ObjectProperty ;
+      rdfs:label "distribution has parameter" .
+
+<http://www.probonto.org/ontology#PROB_k0000510>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Scaled Inverse Chi-Square" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Scaled Inverse Chi-Square"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{(\\nu/2)^{\\nu/2}}{\\Gamma(\\nu/2)}\\sigma^\\nu x^{-(\\nu/2+1)} \\exp\\Big(-\\frac{1}{2}\\nu \\sigma^2 \\frac{1}{x}\\Big)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(nu/2)^(nu/2)/gamma(nu/2)*sigma^nu*x^(-(nu/2+1))*exp(-1/2*nu*sigma^2*1/x)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000463>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Rayleigh 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Rayleigh 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{x}{\\sigma^2} e^{-x^2/(2\\sigma^2)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "x/sigma^2 * exp(-x^2/(2*sigma^2))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000002>
+      a       owl:Class ;
+      rdfs:label "integer" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000001> .
+
+<http://www.probonto.org/ontology#PROB_k0001414>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Kumaraswamy 1 and Exponential 1 whereby \\\\text{If } X \\\\sim Kumaraswamy11,b \\\\text{ then } -1-\\\\logX \\\\sim Exponential1b" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001360> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000418> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X \\sim Kumaraswamy1(1,b) \\text{ then } -(1-\\log(X)) \\sim Exponential1(b)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Kumaraswamy1(a,b) \\rightarrow Exponential1(b)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/Kumaraswamy_distribution}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000535>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Skew Normal" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Skew Normal"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "SkewNormal1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000536> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000537> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000538> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000539> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000541> , <http://www.probonto.org/ontology#PROB_k0000542> , <http://www.probonto.org/ontology#PROB_k0000540> .
+
+<http://www.probonto.org/ontology#PROB_k0000936>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Log-Normal 3 and Log-Normal 6 whereby m = m,  
+\\\\sigma_g=\\\\exp\\\\sigma""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000478> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000553> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """m = m,  
+\\sigma_g=\\exp(\\sigma)"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal3(m,\\sigma) \\rightarrow LogNormal6(m,\\sigma_g)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000267>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac12\\left[1 + \\text{erf}\\left( \\frac{x-\\mu}{\\sqrt{v}\\sqrt{2}}\\right)\\right]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/2 * (1 + erf((x-mu)/(sqrt(var)*sqrt(2))))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001435>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Beta 1 and Standard Uniform 1 whereby \\\\alpha=1, \\\\beta = 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000057> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000587> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\alpha=1, \\beta = 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Beta1(\\alpha,\\beta) \\rightarrow StandardUniform1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{forbes2011statistical}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000339>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "inverse scale of Logistic-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "inverse scale of Logistic-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Logistic2.inverseScale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\tau"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\tau > 0, \\tau \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "inverse scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "inverseScale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000023>
+      a       owl:Class ;
+      rdfs:label "probability density function" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000017> .
+
+<http://www.probonto.org/ontology#PROB_k0001381>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Standard Two-Sided Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Standard Two-Sided Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+x^n m^{1-n}                &\\text{ for } 0 < x < m \\\\
+1-(1-m) ((1-x)/(1-m))^n    &\\text{ for } m \\leq x < 1 
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """CDF1 = function(x,m,n) { x^n * m^(1-n) }
+CDF2 = function(x,m,n) { 1-(1-m)*((1-x)/(1-m))^n }"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001170>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Beta Negative Binomial1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Beta Negative Binomial1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+\\frac{n\\beta}{\\alpha-1} & \\text{if}\\ \\alpha>1 \\\\
+\\infty & \\text{otherwise}\\ \\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001199>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Wigner Semicircle 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Wigner Semicircle 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001382>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Standard Two-Sided Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Standard Two-Sided Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{(n-1)m+1}{n+1}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000689>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "upper bound of Truncated-Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "upper bound of Truncated-Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "TruncatedNormal1.upperBound"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "b \\in R, b > a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "upper bound"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "upperBound"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000576>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(k \\,-\\, 1)\\theta \\text{ for } k \\;{\\geq}\\; 1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000612>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Lomax-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Lomax-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Lomax1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000916>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Log-Normal 1 and Log-Normal 6 whereby m=\\\\exp\\\\mu, 
+\\\\sigma_g=\\\\exp\\\\sigma""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000428> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000553> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """m=\\exp(\\mu), 
+\\sigma_g=\\exp(\\sigma)"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal1(\\mu,\\sigma) \\rightarrow LogNormal6(m,\\sigma_g)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000043>
+      a       owl:ObjectProperty ;
+      rdfs:label "distribution has median" .
+
+<http://www.probonto.org/ontology#PROB_k0000660>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "event probabilities of Multinomial-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "event probabilities of Multinomial-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Multinomial1.probabilityOfSuccess"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "p_1, \\ldots, p_k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "p_1, \\ldots, p_k, \\Sigma p_i = 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "event probabilities"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "probabilityOfSuccess"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000464>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Rayleigh 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Rayleigh 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1 - e^{-x^2/(2\\sigma^2)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1 - exp(-x^2/(2*sigma^2))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000065>
+      a       owl:Class ;
+      rdfs:label "Reparameterisation" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000063> .
+
+<http://www.probonto.org/ontology#PROB_k0001415>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Zipf 1 and Uniform Discrete 1 whereby \\\\alpha = 0, a = 1, b = n" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001286> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000727> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\alpha = 0, a = 1, b = n"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Zipf1(\\alpha,n)  \\rightarrow UniformDiscrete1(a,b)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/ZipfDiscreteuniform.pdf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000003>
+      a       owl:Class ;
+      rdfs:label "natural number" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000002> .
+
+<http://www.probonto.org/ontology#PROB_k0001109>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Arcsine 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Arcsine 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(a+b)/2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000536>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Skew Normal" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Skew Normal"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\sigma \\sqrt{2\\pi}} \\exp\\Big[-\\frac{1}{2}\\Big(\\frac{x-\\mu}{\\sigma} \\Big)^2\\Big] \\Big[1+\\mbox{erf} \\Big(\\alpha\\Big(\\frac{x-\\mu}{ \\sigma\\sqrt{2} }\\Big)\\Big)\\Big]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(sigma*sqrt(2*pi)) * exp(-1/2*((x-mu)/sigma)^2) * (1+erf(alpha*((x-mu)/(sigma*sqrt(2)))))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000022>
+      a       owl:Class ;
+      rdfs:label "parameterised probability distribution" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000020> .
+
+<http://www.probonto.org/ontology#PROB_k0001434>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between NoncentralT and Student's t-distribution 1 whereby \\\\delta=0" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001162> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000613> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\delta=0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NoncentralT1(\\delta,n) \\rightarrow StudentT1(n)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/NoncentraltT.pdf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000266>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\sqrt{v} \\sqrt{2 \\pi}}e^{-\\frac{(x-\\mu)^2}{2v}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(sqrt(var)*sqrt(2*pi))*exp(-(x-mu)^2/(2*var))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001380>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Standard Two-Sided Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Standard Two-Sided Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+n \\left(\\frac{x}{m}\\right)^{n-1} &\\text{ for } 0 < x < m \\\\
+n \\left(\\frac{1-x}{1-m}\\right)^{n-1} &\\text{ for } m \\leq x < 1
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """PDF1 = function(x,m,n) { n*(x/m)^(n-1) }
+PDF2 = function(x,m,n) { n*((1-x)/(1-m))^(n-1) }"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001329>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Johnson SU 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Johnson SU 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{e^{-\\frac12 \\left( \\gamma + \\delta \\,\\text{arcsinh}\\left[\\frac{x-\\mu}{\\sigma}\\right]\\right)^2} \\delta}{\\sqrt{2\\pi} \\sqrt{(x-\\mu)^2 + \\sigma^2}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp(-1/2 * (gamma+delta *asinh((x-mu)/sigma))^2)* delta / (sqrt(2*pi)*sqrt((x-mu)^2 + sigma^2))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001171>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Beta-Negative-Binomial1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Beta-Negative-Binomial1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "BetaNegativeBinomial1.shape1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000915>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 2 and Log-Normal 1 whereby \\\\mu = \\\\mu, \\\\sigma = \\\\sqrt{v}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000453> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000428> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = \\mu, \\sigma = \\sqrt{v}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal2(\\mu,v) \\rightarrow LogNormal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000688>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "lower bound of Truncated-Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "lower bound of Truncated-Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "TruncatedNormal1.lowerBound"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "a \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "lower bound"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "lowerBound"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001309>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Epanechnikov 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Epanechnikov 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Epanechnikov1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001310> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001311> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001312> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001313> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [-1,1]"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000935>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 4 and Log-Normal 1 whereby \\\\mu = \\\\logm, \\\\sigma = \\\\sqrt{\\\\logcv^2+1}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000500> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000428> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = \\log(m), \\sigma = \\sqrt{\\log(cv^2+1)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal4(m,cv) \\rightarrow LogNormal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000661>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Triangular 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Triangular 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Triangular1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000662> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000663> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000664> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000665> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000666> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "a \\leq x \\leq b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000667> , <http://www.probonto.org/ontology#PROB_k0000668> , <http://www.probonto.org/ontology#PROB_k0000669> .
+
+<http://www.probonto.org/ontology#PROB_k0000613>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "t-distribution"^^<en> , "Student's t-distribution 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Student's t-distribution 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StudentT1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000614> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000615> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000616> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000617> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000618> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000619> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000620> .
+
+<http://www.probonto.org/ontology#PROB_c0000042>
+      a       owl:ObjectProperty ;
+      rdfs:label "distribution has mean" .
+
+<http://www.probonto.org/ontology#PROB_k0000465>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Rayleigh 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Rayleigh 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sigma \\sqrt{\\frac{\\pi}{2}}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000575>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\text{No simple closed form}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000379>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Log-Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Log-Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{1+(x/\\alpha)^{-\\beta}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1 / (1+(x/alpha)^(-beta))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000064>
+      a       owl:Class ;
+      rdfs:label "Special case" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000063> .
+
+<http://www.probonto.org/ontology#PROB_c0000021>
+      a       owl:Class ;
+      rdfs:label "parametric probability distribution" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000020> .
+
+<http://www.probonto.org/ontology#PROB_c0000049>
+      a       owl:DatatypeProperty ;
+      rdfs:label "parameter has definition expressed in plain text" .
+
+<http://www.probonto.org/ontology#PROB_k0000801>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Weibull 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Weibull 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{k}{\\lambda}\\left(\\frac{x}{\\lambda}\\right)^{k-1}e^{-(x/\\lambda)^{k}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "k/lambda * (x/lambda)^(k-1) * exp(-(x/lambda)^k)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000261>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Laplace 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Laplace 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001197>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Wigner Semicircle 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Wigner Semicircle 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001360>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Minimax distribution"^^<en> , "Kumaraswamy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Kumaraswamy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Kumaraswamy1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001361> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001362> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0001364> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0001363> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001365> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0001366> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0001367> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [0,1]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001368> , <http://www.probonto.org/ontology#PROB_k0001369> .
+
+<http://www.probonto.org/ontology#PROB_k0000554>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Log-Normal 6" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Log-Normal 6"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{x\\log(\\sigma_g)\\sqrt{2 \\pi}} \\exp\\Big[ \\frac{-[\\log(x/m)]^2}{2 \\log^2(\\sigma_g)}\\Big]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(x*log(sigma_g)*sqrt(2*pi))*exp(-(log(x/m))^2/(2*log(sigma_g)^2))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000618>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Student's t-distribution 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Student's t-distribution 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001433>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Power-Normal 1 and Log-Normal 1 whereby PowerNormal1 \\\\text{ distribution converges to LogNormal1 one when } \\\\lambda \\\\rightarrow 0" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001230> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000428> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "PowerNormal1 \\text{ distribution converges to LogNormal1 one when } \\lambda \\rightarrow 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "PowerNormal1(\\lambda,\\mu,\\sigma) \\rightarrow LogNormal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{LavielleBook:2014}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000079>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Negative Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Negative Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{r(1-p)}{p^2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000533>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of logx of Log-Normal-5" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of log(x) of Log-Normal-5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal5.meanLog"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean of log(x)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "meanLog"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000486>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Log-Normal-3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Log-Normal-3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal3.stdevLog"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "stdevLog"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001104>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Arcsine 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Arcsine 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{8}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000704>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Uniform 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+                  \\frac{1}{b - a} & \\text{for } x \\in [a,b]  \\\\
+                  0               & \\text{otherwise}
+                \\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(b-a)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000574>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "k \\theta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000008>
+      a       owl:Class ;
+      rdfs:label "non numerical set" .
+
+<http://www.probonto.org/ontology#PROB_k0000513>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Scaled Inverse Chi-Square" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Scaled Inverse Chi-Square"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\nu \\sigma^2}{\\nu + 2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000241>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac12\\left[1 + \\text{erf}\\left( \\frac{x-\\mu}{\\sigma\\sqrt{2}}\\right)\\right]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/2 * (1 + erf((x-mu)/(sigma*sqrt(2))))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000409>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Log-Logistic-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Log-Logistic-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogLogistic2.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\kappa"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\kappa > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000466>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Rayleigh 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Rayleigh 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sigma \\sqrt{\\log(4)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001308>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Standard Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Standard Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "undefined"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001177>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Weibull Discrete 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Weibull Discrete 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(1-p)^{x^\\beta} - (1-p)^{(x+1)^\\beta}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(1-p)^(x^beta) - (1-p)^((x+1)^beta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000914>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Binomial 1 and Binomial 2 whereby \\\\alpha = \\\\logp/1-p" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000117> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000149> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\alpha = \\log(p/(1-p))"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Binomial1(n,p) \\rightarrow Binomial2(n,\\alpha)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000260>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Laplace 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Laplace 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000800>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Weibull 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Weibull 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Weibull1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000801> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000802> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0000804> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0000803> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000805> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000806> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000807> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000808> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000810> , <http://www.probonto.org/ontology#PROB_k0000809> .
+
+<http://www.probonto.org/ontology#PROB_k0000913>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Gamma 1 and Erlang 1 whereby k \\\\in N, k=c, \\\\theta=b" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000571> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000392> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "k \\in N, k=c, \\theta=b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Gamma1(k,\\theta) \\rightarrow Erlang1(b,c)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{forbes2011statistical} \\\\
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/GammaErlang.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000048>
+      a       owl:DatatypeProperty ;
+      rdfs:label "parameter has definition" .
+
+<http://www.probonto.org/ontology#PROB_c0000020>
+      a       owl:Class ;
+      rdfs:label "probability distribution" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000005> .
+
+<http://www.probonto.org/ontology#PROB_k0001103>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Arcsine 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Arcsine 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "x \\in \\{0,1\\}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000619>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Student's t-distribution 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Student's t-distribution 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+\\frac{\\nu}{\\nu - 2} & \\text{for }\\nu > 2 \\\\
+\\infty & \\text{for } 1< \\nu \\leq 2 \\\\
+undefined & \\text{else} 
+\\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000051>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Wiener Diffusion Model 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Wiener Diffusion Model 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\alpha}{(x-\\tau)^{3/2}}\\exp\\Big(-\\delta\\alpha\\beta - \\frac{\\delta^2(x-\\tau)}{2}\\Big) \\sum^\\infty_{k=-\\infty}(2k+\\beta)\\phi\\Big(\\alpha\\frac{2k + \\beta}{\\sqrt{x-\\tau}}\\Big)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001198>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Wigner Semicircle 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Wigner Semicircle 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000553>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "lognormal"^^<en> , "Galton"^^<en> , "Log-Normal 6" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Log-Normal 6"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal6"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000554> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000555> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000556> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000557> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000558> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000559> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000561> , <http://www.probonto.org/ontology#PROB_k0000560> .
+
+<http://www.probonto.org/ontology#PROB_k0000078>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Negative Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Negative Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\lfloor \\frac{(1-p)(r-1)}{p} \\rfloor
+"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001432>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label "relationship between Muth 1 and Exponential 2 whereby \\\\text{As } \\\\kappa \\\\rightarrow 0 \\\\text{ for a Muth1}\\\\kappa\\\\text{ , the limiting distribution is Exponential2 with mean 1.}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001344> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000443> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{As } \\kappa \\rightarrow 0 \\text{ for a Muth1(}\\kappa\\text{) , the limiting distribution is Exponential2 with mean 1.}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Muth1(\\kappa) \\rightarrow Exponential2(\\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/MuthExponential.pdf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000534>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "precision of Log-Normal-5" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "precision of Log-Normal-5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal5.precision"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\tau"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\tau > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "precision"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "precision"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000487>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Rician"^^<en> , "Rice 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Rice 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Rice1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000488> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000490> , <http://www.probonto.org/ontology#PROB_k0000491> .
+
+<http://www.probonto.org/ontology#PROB_k0000703>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Uniform 1" , "Rectangular Continuous"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Uniform1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000704> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000705> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000706> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000707> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000708> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000709> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [a,b]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000710> , <http://www.probonto.org/ontology#PROB_k0000711> .
+
+<http://www.probonto.org/ontology#PROB_k0000514>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Scaled Inverse Chi-Square" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Scaled Inverse Chi-Square"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{2\\nu^2 \\sigma^4}{(\\nu - 2)^2(\\nu-4)} \\text{ for } \\nu>4"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000573>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\Gamma(k)} \\gamma\\left(k,\\, \\frac{x}{\\theta}\\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/gamma(k) * Igamma(k,x/theta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000009>
+      a       owl:Class ;
+      rdfs:label "finite set" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000006> .
+
+<http://www.probonto.org/ontology#PROB_k0001178>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Weibull Discrete 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Weibull Discrete 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1-(1-p)^{(x+1)^\\beta}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1-(1-p)^((x+1)^beta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000050>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Wiener Diffusion Model 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Wiener Diffusion Model 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "WienerDiffusionModel1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000051> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000053> , <http://www.probonto.org/ontology#PROB_k0000055> , <http://www.probonto.org/ontology#PROB_k0000054> , <http://www.probonto.org/ontology#PROB_k0000056> .
+
+<http://www.probonto.org/ontology#PROB_k0000467>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Rayleigh 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Rayleigh 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sigma"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000240>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\sigma \\sqrt{2 \\pi}}e^{-\\frac{(x-\\mu)^2}{2\\sigma^2}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(sigma*sqrt(2*pi))*exp(-(x-mu)^2/(2*sigma^2))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001307>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Standard Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Standard Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000408>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Log-Logistic-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Log-Logistic-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogLogistic2.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\lambda > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000729>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Uniform Discrete 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Uniform Discrete 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(k-a+1)/(b-a+1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(k-a+1)/(b-a+1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001195>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Wigner Semicircle 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Wigner Semicircle 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac2{\\pi R^2} \\sqrt{R^2-x^2}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "2/(pi * R^2) * sqrt(R^2-x^2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000407>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Log-Logistic 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Log-Logistic 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\pi \\big( 2\\kappa [1 - \\cos(\\frac{\\pi}{\\kappa})^2] + \\pi \\sin\\big(\\frac{\\pi(\\kappa+2)}{\\kappa}\\big)\\big)}{\\sin\\big(\\frac{\\pi(\\kappa+2)}{\\kappa}\\big)\\big(\\cos^2(\\frac{\\pi}{\\kappa}) -1 \\big) (\\lambda \\kappa)^2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000488>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Rice 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Rice 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{x}{\\sigma^2}\\exp\\left(\\frac{-(x^2+\\nu^2)}{2\\sigma^2}\\right)I_0\\left(\\frac{x\\nu}{\\sigma^2}\\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "x/sigma^2*exp(-(x^2+nu^2)/2/sigma^2) * besselI(x*nu/sigma^2, 0, expon.scaled = FALSE)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000263>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Laplace-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Laplace-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Laplace1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000531>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Log-Normal 5" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Log-Normal 5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "e^{\\mu - \\frac{1}{\\tau}}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000912>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Logistic 2 and Logistic 1 whereby s=1/\\\\tau" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000331> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000307> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "s=1/\\tau"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Logistic2(\\mu,\\tau) \\rightarrow Logistic1(\\mu,s)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001106>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Arcsine 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Arcsine 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\pi\\sqrt{(x-a)(b-x)}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/pi/sqrt((x-a)*(b-x))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001418>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Power 1 and Standard Power 1 whereby \\\\text{The StandardPower1}\\\\beta \\\\text{ distribution is a special case of the Power1}\\\\alpha,\\\\beta \\\\text{ distribution when } \\\\alpha = 1." ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001214> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001351> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{The StandardPower1}(\\beta) \\text{ distribution is a special case of the Power1}(\\alpha,\\beta) \\text{ distribution when } \\alpha = 1."^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Power1(\\alpha,\\beta)  \\rightarrow StandardPower1(\\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/PowerStandardpower.pdf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000880>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 4 and Negative Binomial 5 whereby \\\\alpha = r, \\\\beta = 1-p / p" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000161> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000190> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\alpha = r, \\beta = (1-p) / p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial4(r,p) \\rightarrow NegativeBinomial5(\\alpha, \\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000552>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of minimum of Frechet-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of minimum of Frechet-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Frechet2.locationOfMinimum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "m"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "m \\in (-\\infty, \\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location of minimum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "locationOfMinimum"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001431>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label """relationship between Normal 1 and Folded Normal 1 whereby \\\\text{Given a normally distributed random variable X with mean } \\\\mu \\\\text{ and variance } \\\\sigma^2, \\\\text{ the random}\\\\\\\\
+\\\\text{variable } Y = |X| \\\\text{ has a folded normal distribution}""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001386> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """\\text{Given a normally distributed random variable X with mean } \\mu \\text{ and variance } \\sigma^2, \\text{ the random}\\\\
+\\text{variable } Y = |X| \\text{ has a folded normal distribution}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Normal1(\\mu,\\sigma) \\rightarrow FoldedNormal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/Folded_normal_distribution}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000511>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Scaled Inverse Chi-Square" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Scaled Inverse Chi-Square"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Gamma\\Big(\\frac{\\nu}{2},\\frac{\\sigma^2\\nu}{2x}\\Big)\\Big/\\Gamma\\Big(\\frac{\\nu}{2}\\Big)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "Igamma(nu/2,sigma^2*nu/2/x, lower=F) / gamma(nu/2) \\text{ with } Igamma(a, x, lower=F)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000841>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Normal 1 and Standard Normal 1 whereby \\\\mu = 0, \\\\sigma = 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000562> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = 0, \\sigma = 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Normal1(\\mu,\\sigma) \\rightarrow StandardNormal1(0,1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/NormalStandardnormalT.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000006>
+      a       owl:Class ;
+      rdfs:label "mathematical set" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000005> .
+
+<http://www.probonto.org/ontology#PROB_k0000572>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\Gamma(k) \\theta^k} x^{k \\,-\\, 1} e^{-\\frac{x}{\\theta}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1 / (gamma(k) * theta^k) * x^(k-1) * exp(-x/theta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000702>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "vector of positive inverse scales of Multivariate-Gaussian-Process-Distribution-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "vector of positive inverse scales of Multivariate-Gaussian-Process-Distribution-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateGaussianProcess2.inverseScale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "w"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "w \\in R^K, K \\in N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "vector of positive inverse scales"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "inverseScale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000047>
+      a       owl:ObjectProperty ;
+      rdfs:label "distribution has nth parameter" .
+
+<http://www.probonto.org/ontology#PROB_k0001175>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Geometric 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Geometric 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(1 - p)^k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(1 - p)^k"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000243>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001194>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Wigner Semicircle 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Wigner Semicircle 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "WignerSemicircle1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001195> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001196> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001197> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0001198> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0001199> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001200> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-R,R)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001201> .
+
+<http://www.probonto.org/ontology#PROB_k0001306>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Standard Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Standard Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000616>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Student's t-distribution 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Student's t-distribution 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+0 & \\text{for }\\nu > 1 \\\\ undefined & \\text{else} 
+\\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000468>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Rayleigh 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Rayleigh 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{4 - \\pi}{2} \\sigma^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000406>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Log-Logistic 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Log-Logistic 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1/\\lambda"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000939>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 3 and Negative Binomial 6 whereby \\\\eta = \\\\log\\\\mu" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000135> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000217> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\eta = \\log(\\mu)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial3(\\mu,\\phi) \\rightarrow NegativeBinomial6(\\eta,\\phi)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{stan-manual:2015b}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000053>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "boundary separation of Wiener-Diffusion-Model-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "boundary separation of Wiener-Diffusion-Model-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "WienerDiffusionModel1.boundSeparation"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha \\in R^+"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "boundary separation"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "boundSeparation"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001196>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Wigner Semicircle 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Wigner Semicircle 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac12 \\frac{x\\sqrt{R^2-x^2}}{\\pi R^2} + \\frac{\\arcsin(\\frac{x}{R})}{\\pi}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/2 * (x*sqrt(R^2-x^2))/(pi * R^2) + asin(x/R)/pi"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000617>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Student's t-distribution 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Student's t-distribution 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000262>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Laplace 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Laplace 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "2 b^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000911>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label """relationship between Uniform 1 and Standard Uniform 1 whereby a = 0, 
+b = 1""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000703> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000587> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """a = 0, 
+b = 1"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Uniform1(a,b) \\rightarrow StandardUniform1(0,1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/UniformStandarduniform.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001105>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Arcsine 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Arcsine 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Arcsine2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001106> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001107> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001108> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0001109> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0001110> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001111> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (a,b)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001113> , <http://www.probonto.org/ontology#PROB_k0001112> .
+
+<http://www.probonto.org/ontology#PROB_k0000532>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Log-Normal 5" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Log-Normal 5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "e^{2\\mu + \\frac{1}{\\tau}}[e^{\\frac{1}{\\tau}}-1]"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001430>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Two-Sided Power 1 and Standard Two-Sided Power 1 whereby a=0, b=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001151> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001379> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "a=0, b=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "TwoSidedPower1(a,b,m,n) \\rightarrow StandardTwoSidedPower1(m,n)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{van2002standard}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000881>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Standard Normal 1 and Normal 1 whereby X \\\\sim StandardNormal1 \\\\text{ and } Y = \\\\mu + \\\\sigma X \\\\Rightarrow Y \\\\sim Normal1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000562> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "X \\sim StandardNormal1 \\text{ and } Y = \\mu + \\sigma X \\Rightarrow Y \\sim Normal1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StandardNormal1(0,1) \\rightarrow Normal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/StandardnormalNormal.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000551>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Frechet-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Frechet-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Frechet2.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma \\in (0, \\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001419>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Standard Power 1 and Standard Uniform 1 whereby \\\\text{StandardUniform1 distribution is a special case of the StandardPower1}\\\\beta \\\\text{ distribution when } \\\\beta=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001351> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000587> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{StandardUniform1 distribution is a special case of the StandardPower1}(\\beta) \\text{ distribution when } \\beta=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StandardPower1(\\beta) \\rightarrow StandardUniform1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/StandardpowerStandarduniform.pdf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000512>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Scaled Inverse Chi-Square" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Scaled Inverse Chi-Square"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\nu \\sigma^2}{\\nu - 2} \\text{ for } \\nu>2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000571>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Gamma1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000572> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000573> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0001079> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000574> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000575> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000576> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000577> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000578> , <http://www.probonto.org/ontology#PROB_k0000579> .
+
+<http://www.probonto.org/ontology#PROB_k0000840>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Skew Normal and Chi-squared 1 whereby \\\\text{If } X \\\\sim SkewNormal1\\\\mu,\\\\sigma,\\\\alpha \\\\text{ then } X^2 \\\\sim ChiSquared11" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000535> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000299> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X \\sim SkewNormal1(\\mu,\\sigma,\\alpha) \\text{ then } X^2 \\sim ChiSquared1(1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "SkewNormal1(\\mu,\\sigma,\\alpha) \\rightarrow ChiSquared1(k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://azzalini.stat.unipd.it/SN/Intro/intro.html}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000701>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "lower triangular matrix of Multivariate-Gaussian-Process-Distribution-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "lower triangular matrix of Multivariate-Gaussian-Process-Distribution-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateGaussianProcess2.choleskyFactor"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "L"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "L \\in R^{N \\times N}, \\text{ lower triangular and such that } LL^T \\text{ is positive kernel definite}, \\text{with } N \\in N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "lower triangular matrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "choleskyFactor"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000007>
+      a       owl:Class ;
+      rdfs:label "numerical set" .
+
+<http://www.probonto.org/ontology#PROB_k0001305>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Standard Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Standard Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "undefined"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000242>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000060>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has short code name" .
+
+<http://www.probonto.org/ontology#PROB_k0001176>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Weibull Discrete 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Weibull Discrete 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "WeibullDiscrete1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0001177> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001178> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0001180> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0001179> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,1,2,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001182> , <http://www.probonto.org/ontology#PROB_k0001181> .
+
+<http://www.probonto.org/ontology#PROB_c0000046>
+      a       owl:ObjectProperty ;
+      rdfs:label "distribution has relation of type to" .
+
+<http://www.probonto.org/ontology#PROB_k0000469>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Rayleigh-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Rayleigh-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Rayleigh1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000357>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Logit Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Logit Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\text{ no analytical solution }"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000034>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Gumbel 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Gumbel 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "e^{-e^{-(x-\\mu)/\\beta}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp(-exp(-(x-mu)/beta))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000862>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Chi-squared 1 and Exponential 1 whereby k=2 \\\\text{ and } \\\\lambda=1/2" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000299> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000418> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "k=2 \\text{ and } \\lambda=1/2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "ChiSquared1(k) \\rightarrow Exponential1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/ChisquareExponential.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000805>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Weibull 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Weibull 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lambda \\, \\Gamma(1+1/k)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001304>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Standard Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Standard Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\pi - 2\\arctan(x)}{2\\pi}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(pi - 2*atan(x))/2/pi"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000930>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 1 and Log-Normal 4 whereby m = \\\\exp\\\\mu, cv = \\\\sqrt{\\\\exp\\\\sigma^2 - 1}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000428> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000500> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "m = \\exp(\\mu), cv = \\sqrt{\\exp(\\sigma^2) - 1}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal1(\\mu,\\sigma) \\rightarrow LogNormal4(m,cv)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000132>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "population size of Hypergeometric-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "population size of Hypergeometric-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Hypergeometric1.populationSize"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "N \\in \\left\\{0,1,2,\\dots\\right\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "population size"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "populationSize"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000683>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Truncated Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Truncated Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\Phi(\\frac{x-\\mu}{\\sigma})-\\Phi(\\frac{a-\\mu}{\\sigma})}{\\Phi(\\frac{b-\\mu}{\\sigma})-\\Phi(\\frac{a-\\mu}{\\sigma})}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """( Phi((x-mu)/sigma)-Phi((a-mu)/sigma) ) / ( Phi((b-mu)/sigma)-Phi((a-mu)/sigma) )
+
+Phi = function(x) {  1/2 * (1 + erf(x/(sqrt(2)))) }
+erf = function(x) {  2 * pnorm(x * sqrt(2)) - 1 }"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000095>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "number of trials of Beta-binomial-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "number of trials of Beta-binomial-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "BetaBinomial1.numberOfTrials"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "n"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "n \\in N, n > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "number of trials"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "numberOfTrials"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000094>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Beta-binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Beta-binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{n\\alpha\\beta(\\alpha+\\beta+n)}{(\\alpha+\\beta)^2(\\alpha+\\beta+1)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000769>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Multivariate Normal 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Multivariate Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000882>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Negative Binomial 1 and Geometric 1 whereby n=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000074> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000782> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "n=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial1(r,p) \\rightarrow Geometric1(p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/PascalGeometric.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000075>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Negative Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Negative Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\binom {k+r-1}k p^r (1-p)^k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "choose(k+r-1,k) * p^r * (1-p)^k"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000642>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Student-s-t-distribution-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Student-s-t-distribution-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StudentT2.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\tau"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\tau > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000708>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Uniform 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\text{any value in }[a,b]"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001213>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "NA of Makeham-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "NA of Makeham-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Makeham1.gamma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\gamma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\gamma > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "gamma"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000910>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 1 and Log-Normal 2 whereby \\\\mu = \\\\mu, v = \\\\sigma^2 " ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000428> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000453> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = \\mu, v = \\sigma^2 "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal1(\\mu,\\sigma) \\rightarrow LogNormal2(\\mu,v)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000747>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Multivariate Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Multivariate Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "T^{-1}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000558>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Log-Normal 6" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Log-Normal 6"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "m / e^{\\log^2(\\sigma_g)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001364>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Kumaraswamy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Kumaraswamy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(1-x^a)^b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "-(1-x^a)^b"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001127>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Noncentral chi-squared 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Noncentral chi-squared 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NoncentralChiSquared1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001128> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001129> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001130> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001131> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001132> , <http://www.probonto.org/ontology#PROB_k0001133> .
+
+<http://www.probonto.org/ontology#PROB_k0000727>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Uniform Discrete 1" , "Rectangular Discrete 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Uniform Discrete 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "UniformDiscrete1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000728> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000729> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000730> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000731> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000732> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{a,a+1,...,b-1,b\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000733> , <http://www.probonto.org/ontology#PROB_k0000734> .
+
+<http://www.probonto.org/ontology#PROB_k0000054>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "initial bias of Wiener-Diffusion-Model-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "initial bias of Wiener-Diffusion-Model-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "WienerDiffusionModel1.initialBias"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta \\in [0,1]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "initial bias"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "initialBias"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001324>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Standard Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Standard Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001080>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Log-Normal 7" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Log-Normal 7"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac12 + \\frac12\\,\\text{erf}\\Big[\\frac{\\log x-\\log(\\frac{\\mu_N}{\\sqrt{\\sigma_N^2/\\mu_N^2 + 1}})}{\\sqrt{2 \\log(1+\\sigma_N^2/\\mu_N^2)}}\\Big]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/2 + 1/2 * erf( (log(x)-log(mu_N/sqrt(sigma_N^2/mu_N^2 + 1))) / sqrt(2 * log(1+sigma_N^2/mu_N^2)) )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000358>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Logit Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Logit Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\text{ no analytical solution }"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000131>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Hypergeometric 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Hypergeometric 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "n{K\\over N}{(N-K)\\over N}{N-n\\over N-1}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000035>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Gumbel 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Gumbel 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu + \\beta\\,\\gamma_E; \\text{ with is Euler constant } \\gamma_E"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001303>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Standard Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Standard Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac2{(1+x^2)(\\pi - 2\\arctan(x))}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "2/(1+x^2)/(pi - 2*atan(x))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000804>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Weibull 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Weibull 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\exp(-(x/\\lambda)^k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp(-(x/lambda)^k)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000863>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Normal 1 and Normal 3 whereby \\\\mu = \\\\mu, 
+\\\\tau = 1 / \\\\sigma^2 """ ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000290> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """\\mu = \\mu, 
+\\tau = 1 / \\sigma^2 """^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Normal1(\\mu,\\sigma) \\rightarrow Normal3(\\mu,\\tau)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000682>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Truncated Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Truncated Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\frac{1}{\\sigma} \\phi(\\frac{x-\\mu}{\\sigma})}{\\Phi(\\frac{b-\\mu}{\\sigma})-\\Phi(\\frac{a-\\mu}{\\sigma})}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """( 1/sigma * phi((x-mu)/sigma) ) / ( Phi((b-mu)/sigma)-Phi((a-mu)/sigma) )
+
+phi = function(x) {  1/(sqrt(2*pi))*exp(-x^2/2) }
+Phi = function(x) {  1/2 * (1 + erf(x/(sqrt(2)))) }
+erf = function(x) {  2 * pnorm(x * sqrt(2)) - 1 }"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000883>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Gamma 1 and Gamma 2 whereby r=k, \\\\mu = 1/ \\\\theta" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000571> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000597> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "r=k, \\mu = 1/ \\theta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Gamma1(k,\\theta) \\rightarrow Gamma2(r,\\mu) "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000093>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Beta-binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Beta-binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{n\\alpha}{\\alpha+\\beta}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001323>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Standard Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Standard Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{e^{x}}{1+e^{x}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp(x)/(1+exp(x))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000707>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Uniform 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\tfrac{1}{2}(a+b)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000074>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Negative Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Negative Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000075> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000076> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000077> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000078> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000079> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,1,2,3,\\dots\\} \\text{ -- number of failures}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000080> , <http://www.probonto.org/ontology#PROB_k0000081> .
+
+<http://www.probonto.org/ontology#PROB_k0000330>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "rate of decay of Conway-Maxwell-Poisson-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "rate of decay of Conway-Maxwell-Poisson-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ConwayMaxwellPoisson1.rateOfDecay"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\nu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\nu \\ge 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "rate of decay"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "rateOfDecay"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000643>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degrees of freedom of Student-s-t-distribution-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degrees of freedom of Student-s-t-distribution-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StudentT2.degreesOfFreedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "k \\ge 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degrees of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "degreesOfFreedom"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000055>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "drift rate of Wiener-Diffusion-Model-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "drift rate of Wiener-Diffusion-Model-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "WienerDiffusionModel1.driftRate"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\delta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\delta \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "drift rate"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "driftRate"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000748>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Multivariate-Normal-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Multivariate-Normal-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateNormal2.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R^k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001212>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "NA of Makeham-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "NA of Makeham-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Makeham1.kappa"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\kappa"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\kappa > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "kappa"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000530>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Log-Normal 5" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Log-Normal 5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "e^\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001128>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Noncentral chi-squared 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Noncentral chi-squared 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sum^\\infty_{k=0} \\frac{e^{-\\delta/2} (\\delta/2)^k}{k!} \\frac{e^{-x/2} x^{(n+2k)/2-1}}{2^{(n+2k)/2} \\Gamma[(n+2k)/2]}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """sumFromTo = function(x,delta,n,fromValue,toValue) {
+  PDF=array(0,length(x));
+  for(j in 1:length(x)) {
+    for(i in fromValue:toValue) {
+      PDF[j] = PDF[j] + exp(-delta/2)*(delta/2)^i/factorial(i) * (exp(-x[j]/2)*x[j]^((n+2*i)/2-1)) / (2^((n+2*i)/2)*gamma((n+2*i)/2))
+    }
+  }
+  return(PDF)
+}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001363>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Kumaraswamy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Kumaraswamy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{a \\,b \\,x^{a-1}}{ (1-x^a)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "a*b*x^(a-1) / (1-x^a)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000557>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Log-Normal 6" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Log-Normal 6"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "m"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000728>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Uniform Discrete 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Uniform Discrete 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1/(b-a+1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(b-a+1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000134>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "number of trials of Hypergeometric-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "number of trials of Hypergeometric-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Hypergeometric1.numberOfTrials"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "n"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "n \\in \\left\\{0,1,2,\\dots,N\\right\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "number of trials"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "numberOfTrials"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000864>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label "relationship between Zero-Inflated Negative Binomial 1 and Poisson 1 whereby p0=0, \\\\tau \\\\rightarrow 0" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000142> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000410> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "p0=0, \\tau \\rightarrow 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "ZeroInflatedNegativeBinomial1(\\lambda,\\tau,p0) \\rightarrow Poisson1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{Troconiz:2009fv}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001302>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Standard Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Standard Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\pi + 2\\arctan(x)}{2\\pi}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(pi + 2*atan(x))/2/pi"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000036>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Gumbel 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Gumbel 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu - \\beta\\,\\ln(\\ln(2))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000359>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Logit-Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Logit-Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogitNormal1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001179>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Weibull Discrete 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Weibull Discrete 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1-(1-p)^{(x+1)^\\beta-x^\\beta}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1-(1-p)^((x+1)^beta-x^beta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000725>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Multivariate-Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Multivariate-Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateNormal1.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R^k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000097>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "right beta parameter of Beta-binomial-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "right beta parameter of Beta-binomial-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "BetaBinomial1.beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "right beta parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "beta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000681>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Truncated Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Truncated Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "TruncatedNormal1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000682> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000683> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000684> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000685> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [a,b]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000689> , <http://www.probonto.org/ontology#PROB_k0000688> , <http://www.probonto.org/ontology#PROB_k0000687> , <http://www.probonto.org/ontology#PROB_k0000686> .
+
+<http://www.probonto.org/ontology#PROB_k0000950>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 2 and Log-Normal 3 whereby m = \\\\exp\\\\mu, \\\\sigma = \\\\sqrt{v}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000453> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000478> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "m = \\exp(\\mu), \\sigma = \\sqrt{v}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal2(\\mu,v) \\rightarrow LogNormal3(m,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000668>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "upper limit of Triangular-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "upper limit of Triangular-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Triangular1.upperLimit"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "b \\in R, a < b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "upper limit"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "upperLimit"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001029>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Log-Normal 7" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Log-Normal 7"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{x \\sqrt{2 \\pi \\log\\Big(1+\\sigma_N^2/\\mu_N^2\\Big)}} \\exp\\Bigg( \\frac{-\\Big[ \\log(x) - \\log\\Big(\\frac{\\mu_N}{\\sqrt{1+\\sigma_N^2/\\mu_N^2}}\\Big)\\Big]^2}{2\\log\\Big(1+\\sigma_N^2/\\mu_N^2\\Big)}\\Bigg)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """1 / (x * sqrt(2 * pi * log(1+sigma_N^2/mu_N^2 ) )) 
+* exp( -( log(x) - log(mu_N/sqrt(1+sigma_N^2/mu_N^2)) )^2 / (2*log(1+sigma_N^2/mu_N^2)) )"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000331>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Logistic 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Logistic 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Logistic2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000332> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000333> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000334> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000335> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000336> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000337> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000339> , <http://www.probonto.org/ontology#PROB_k0000338> .
+
+<http://www.probonto.org/ontology#PROB_k0000706>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Uniform 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\tfrac{1}{2}(a+b)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001215>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\beta x^{\\beta-1}}{\\alpha^\\beta}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(beta * x^(beta-1))/alpha^beta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001322>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Standard Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Standard Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{e^{x}}{\\left(1+e^{x}\\right)^2}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp(x) / (1+exp(x))^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000077>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Negative Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Negative Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{r(1-p)}{p}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000556>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Log-Normal 6" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Log-Normal 6"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "m\\,e^{\\frac{1}{2} \\log^2(\\sigma_g)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001362>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Kumaraswamy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Kumaraswamy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1-(1-x^a)^b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1-(1-x^a)^b"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000884>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Generalized Negative Binomial 1 and Inverse Binomial 1 whereby \\\\beta=2, \\\\theta=1-p" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000690> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000154> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\beta=2, \\theta=1-p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "GeneralizedNegativeBinomial1(\\theta,\\beta,m) \\rightarrow InverseBinomial1(k,p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{yanagimoto1989inverse}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001129>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Noncentral chi-squared 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Noncentral chi-squared 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """e^{-\\delta/2} \\sum^\\infty_{k=0} \\frac{(\\delta/2)^k}{k!} Q(x;n+2k)\\\\
+\\text{ with } Q(x;p) = \\frac{\\gamma(p/2,x/2)}{\\Gamma(p/2)}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """CDF = function(x,delta,n,lowerLimit,upperLimit) { exp(-delta/2) * CDFsum(x,n,delta,0,Ninfty) }
+CDFsum = function(x,n,delta,fromValue,toValue) { 
+  CDF=array(0,length(x));
+  for(j in 1:length(x)) {
+    for(k in fromValue:toValue) {
+      CDF[j] = CDF[j] + (delta/2)^k/factorial(k) * Igamma((n+2*k)/2,x[j]/2,lower=T)/gamma((n+2*k)/2)
+    }
+  }
+  return(CDF)
+}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000970>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Log-Normal 2 and Log-Normal 5 whereby \\\\mu = \\\\mu, 
+\\\\tau = 1 / v""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000453> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000526> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """\\mu = \\mu, 
+\\tau = 1 / v"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal2(\\mu,v) \\rightarrow LogNormal5(\\mu,\\tau)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000745>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Multivariate Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Multivariate Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000803>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Weibull 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Weibull 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{k}\\lambda \\Big(\\frac{x}\\lambda\\Big)^{k-1}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "k/lambda *(x/lambda)^(k-1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000640>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Student's t-distribution 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Student's t-distribution 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\tau} \\frac{k}{k-2} \\text{ for } k > 2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000056>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "nondecision time of Wiener-Diffusion-Model-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "nondecision time of Wiener-Diffusion-Model-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "WienerDiffusionModel1.nondecisionTime"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\tau"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\tau \\in R^+"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "nondecision time"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "nondecisionTime"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000133>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "number of successes of Hypergeometric-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "number of successes of Hypergeometric-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Hypergeometric1.numberOfSuccesses"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "K"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "K \\in \\left\\{0,1,2,\\dots,N\\right\\} "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "number of successes"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "numberOfSuccesses"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000865>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Log-Logistic 1 and Logistic 1 whereby \\\\text{If } X \\\\sim LogLogistic1\\\\alpha,\\\\beta \\\\Rightarrow Y = logX \\\\sim Logistic1\\\\mu,s \\\\text{ with } \\\\mu=\\\\log\\\\alpha, s=1/\\\\beta" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000377> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000307> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X \\sim LogLogistic1(\\alpha,\\beta) \\Rightarrow Y = log(X) \\sim Logistic1(\\mu,s) \\text{ with } \\mu=\\log(\\alpha), s=1/\\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogLogistic1(\\alpha,\\beta) \\rightarrow Logistic1(\\mu,s)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/Log-logistic_distribution#Related_distributions}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000726>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "covariance matrix of Multivariate-Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "covariance matrix of Multivariate-Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateNormal1.covarianceMatrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\Sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\Sigma \\in R^{k\\times k}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "covariance matrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "covarianceMatrix"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001389>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Folded Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Folded Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              " \\sigma \\sqrt{\\tfrac{2}{\\pi}} \\, e^{(-\\mu^2/2\\sigma^2)} + \\mu \\left(1 - 2\\,\\Phi(\\tfrac{-\\mu}{\\sigma}) \\right)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000096>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "left beta parameter of Beta-binomial-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "left beta parameter of Beta-binomial-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "BetaBinomial1.alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "left beta parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "alpha"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000680>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "vector of positive inverse scales of Multivariate-Gaussian-Process-Distribution-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "vector of positive inverse scales of Multivariate-Gaussian-Process-Distribution-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateGaussianProcess1.inverseScale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "w"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "w \\in R^K, K \\in N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "vector of positive inverse scales"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "inverseScale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000037>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Gumbel 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Gumbel 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001301>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Standard Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Standard Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac1\\pi \\frac1{1+x^2}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/pi/(1+x^2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001028>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "lognormal"^^<en> , "Galton"^^<en> , "Log-Normal 7" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Log-Normal 7"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal7"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001029> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001080> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001031> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0001032> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0001033> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001034> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001036> , <http://www.probonto.org/ontology#PROB_k0001035> .
+
+<http://www.probonto.org/ontology#PROB_k0000669>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape mode of Triangular-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape (mode) of Triangular-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Triangular1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "c"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "c \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape (mode)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001214>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Power1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001215> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001216> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0001218> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0001217> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001219> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001220> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001222> , <http://www.probonto.org/ontology#PROB_k0001221> .
+
+<http://www.probonto.org/ontology#PROB_k0000332>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Logistic 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Logistic 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\tau e^{-\\tau(x-\\mu)}} {\\left(1+e^{-\\tau(x-\\mu)}\\right)^2}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(tau * exp(-tau*(x-mu))) / (1+exp(-tau*(x-mu)))^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000705>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Uniform 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+                  0               & \\text{for } x < a \\\\
+                  \\frac{x-a}{b-a} & \\text{for } x \\in [a,b) \\\\
+                  1               & \\text{for } x \\ge b
+                \\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(x-a)/(b-a)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000076>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Negative Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Negative Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1 - I_{1-p}(k+1,r)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1 - Rbeta(1-p, k+1, r, lower = T)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001321>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Standard Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Standard Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StandardLogistic1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001322> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001323> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001324> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0001325> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0001326> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001327> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001361>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Kumaraswamy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Kumaraswamy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "a b x^{a-1} (1-x^a)^{b-1}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "a*b*x^(a-1) * (1-x^a)^(b-1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000555>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Log-Normal 6" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Log-Normal 6"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac12 + \\frac12\\,\\text{erf}\\Big[\\frac{\\log x-\\log m}{\\sqrt{2}\\log(\\sigma_g)}\\Big]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/2 + 1/2 * erf( (log(x)-log(m)) / (sqrt(2)*log(sigma_g)) )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000885>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 5 and Negative Binomial 4 whereby r = \\\\alpha, p = 1 / 1 + \\\\beta" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000190> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000161> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "r = \\alpha, p = 1 / (1 + \\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial5(\\alpha, \\beta) \\rightarrow NegativeBinomial4(r,p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000641>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Student-s-t-distribution-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Student-s-t-distribution-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StudentT2.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000802>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Weibull 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Weibull 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1- \\exp(-(x/\\lambda)^k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1- exp(-(x/lambda)^k)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000057>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Beta 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Beta 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Beta1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000058> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000059> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0000061> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0000060> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000062> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000063> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000064> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000065> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000067> , <http://www.probonto.org/ontology#PROB_k0000066> .
+
+<http://www.probonto.org/ontology#PROB_k0000746>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Multivariate Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Multivariate Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001300>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Breit-Wigner"^^<en> , "Standard Cauchy 1" , "Lorentz"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Standard Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StandardCauchy1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001301> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001302> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0001304> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0001303> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001305> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0001306> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0001307> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001308> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in R"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000099>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Hyperbolic secant 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Hyperbolic secant 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\text{sech}\\Big(\\pi x\\Big)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "sech(pi*x)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000070>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Half-normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Half-normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\text{erf}(\\theta x / \\sqrt{\\pi})"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "erf(theta * x / sqrt(pi))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000353>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Logit Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Logit Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\sigma \\sqrt{2 \\pi}}\\, e^{-\\frac{(\\operatorname{logit}(x) - \\mu)^2}{2\\sigma^2}}\\frac{1}{x (1-x)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(sigma * sqrt(2*pi)) * exp(-(logit(x) - mu)^2)/(2*sigma^2)) * 1 / (x*(1-x))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000666>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Triangular 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Triangular 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(a^2 + b^2 + c^2 - ab - ac - bc)/18"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001237>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of YuleSimon1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of YuleSimon1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\rho B(k, \\rho+1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "rho*beta(k,rho+1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000809>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Weibull-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Weibull-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Weibull1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\lambda \\in (0, +\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000934>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Frechet 2 and Weibull 1 whereby X \\\\sim Frechet2\\\\alpha,\\\\sigma,m \\\\text{ with } m=0 \\\\rightarrow X^{-1} \\\\sim Weibull\\\\lambda=1/\\\\sigma,k=\\\\alpha" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000543> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000800> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "X \\sim Frechet2(\\alpha,\\sigma,m) \\text{ with } m=0 \\rightarrow X^{-1} \\sim Weibull(\\lambda=1/\\sigma,k=\\alpha)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Frechet2(\\alpha,\\sigma,m) \\rightarrow Weibull1(\\lambda,k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\url{https://en.wikipedia.org/wiki/Fr%C3%A9chet_distribution} \\\\
+\\cite{stan-manual:2015b}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000723>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Multivariate Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Multivariate Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001388>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Folded Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Folded Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{2}\\left[ \\mbox{erf}\\left(\\frac{x+\\mu}{\\sigma\\sqrt{2}}\\right) + \\mbox{erf}\\left(\\frac{x-\\mu}{\\sigma\\sqrt{2}}\\right)\\right]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/2 * (erf((x-mu)/(sigma*sqrt(2))) + erf((x+mu)/(sigma*sqrt(2))))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000029>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has code name" .
+
+<http://www.probonto.org/ontology#PROB_k0000687>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "standard deviation of Truncated-Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "standard deviation of Truncated-Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "TruncatedNormal1.stdev"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "standard deviation"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "stdev"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001083>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Amoroso 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Amoroso 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac1{\\Gamma(\\alpha)} \\left| \\frac{\\beta}{\\theta}\\right|\\left(\\frac{x-a}{\\theta}\\right)^{\\alpha\\beta-1} \\exp\\left[-\\left(\\frac{x-a}{\\theta}\\right)^\\beta \\right]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/gamma(alpha) * abs(beta/theta) * ((x-a)/theta)^(alpha*beta-1) * exp(-((x-a)/theta)^beta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000058>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Beta 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Beta 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{x^{\\alpha-1}(1-x)^{\\beta-1}} {B(\\alpha,\\beta)} "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(x^(alpha-1)*(1-x)^(beta-1))/beta(alpha,beta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001328>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Johnson SU 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Johnson SU 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSU1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001329> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001330> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001332> , <http://www.probonto.org/ontology#PROB_k0001334> , <http://www.probonto.org/ontology#PROB_k0001333> , <http://www.probonto.org/ontology#PROB_k0001331> .
+
+<http://www.probonto.org/ontology#PROB_k0000886>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Normal 1 and Standard Normal 1 whereby X \\\\sim Normal1\\\\mu,\\\\sigma; Y = X - \\\\mu / \\\\sigma; Y \\\\sim StandardNormal1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000562> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "X \\sim Normal1(\\mu,\\sigma); Y = (X - \\mu) / \\sigma; Y \\sim StandardNormal1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Normal1(\\mu,\\sigma) \\rightarrow StandardNormal1(0,1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/NormalStandardnormalT.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000646>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Generalized Gamma 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Generalized Gamma 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\gamma(c,(\\frac{x-a}{b})^k)}{\\Gamma(c)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "Igamma(c, ((x-a)/b)^k, lower=T) / gamma(c)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001217>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\beta x^{\\beta-1} \\alpha^{-\\beta}}{\\alpha^\\beta - x^\\beta}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(beta * x^(beta-1) * alpha^(-beta)) / (alpha^beta - x^beta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001412>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Amoroso 1 and Frechet 1 whereby \\\\text{Frechet1}\\\\alpha,\\\\sigma \\\\text{ distribution is a special case of the Amoroso1} a,\\\\theta,\\\\alpha,\\\\beta \\\\text{ distribution when } a=0, \\\\theta=\\\\sigma, \\\\alpha=1, \\\\beta rightarrow -\\\\beta" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001082> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000517> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{Frechet1}(\\alpha,\\sigma) \\text{ distribution is a special case of the Amoroso1} (a,\\theta,\\alpha,\\beta) \\text{ distribution when } a=0, \\theta=\\sigma, \\alpha=1, \\beta rightarrow -\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Amoroso1(a,\\theta,\\alpha,\\beta) \\rightarrow Frechet1(\\alpha,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{crooks2010amoroso}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000000>
+      a       owl:Class ;
+      rdfs:label "real number" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000004> .
+
+<http://www.probonto.org/ontology#PROB_k0000333>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Logistic 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Logistic 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{1+e^{-\\tau(x-\\mu)}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(1+exp(-tau*(x-mu)))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001368>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Kumaraswamy-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Kumaraswamy-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Kumaraswamy1.shape1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "a > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000972>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label "relationship between Hypergeometric 1 and Normal 1 whereby X \\\\sim Hypergeometric1N, K, n \\\\Rightarrow Y\\\\sim Normal1\\\\mu,\\\\sigma \\\\text{ for large n, but K/N not too small}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000126> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "X \\sim Hypergeometric1(N, K, n) \\Rightarrow Y\\sim Normal1(\\mu,\\sigma) \\text{ for large n, but K/N not too small}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Hypergeometric1(N,K,n) \\rightarrow Normal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{forbes2011statistical}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000667>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "lower limit of Triangular-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "lower limit of Triangular-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Triangular1.lowerLimit"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "a \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "lower limit"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "lowerLimit"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000354>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Logit Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Logit Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac12\\Big[1 + \\operatorname{erf}\\Big( \\frac{\\operatorname{logit}(x)-\\mu}{\\sqrt{2\\sigma^2}}\\Big)\\Big]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/2*(1 + erf((logit(x)-mu)/sqrt(2*sigma^2))))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001236>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "YuleSimon1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "YuleSimon1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "YuleSimon1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0001237> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001238> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001239> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0001240> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001241> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{1,2,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001242> .
+
+<http://www.probonto.org/ontology#PROB_k0000098>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Hyperbolic secant 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Hyperbolic secant 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "HyperbolicSecant1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000099> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000100> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000101> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000102> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000103> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000104> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001387>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Folded Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Folded Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\sigma\\sqrt{2\\pi}} \\,e^{ -\\frac{(x-\\mu)^2}{2\\sigma^2} } + \\frac{1}{\\sigma\\sqrt{2\\pi}} \\,e^{ -\\frac{(x+\\mu)^2}{2\\sigma^2} }"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(sigma*sqrt(2*pi))*exp(-(x-mu)^2/(2*sigma^2)) + 1/(sigma*sqrt(2*pi))*exp(-(x+mu)^2/(2*sigma^2))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000028>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has name" .
+
+<http://www.probonto.org/ontology#PROB_k0000159>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "index parameter of Inverse-Binomial-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "index parameter of Inverse-Binomial-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "InverseBinomial1.index"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "k \\in \\left\\{0,1,2,\\dots\\right\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "index parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "index"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000933>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Gamma 1 and Chi-squared 1 whereby k_{ChiSquared1}=2k, \\\\theta=2" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000571> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000299> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "k_{ChiSquared1}=2k, \\theta=2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Gamma1(k,\\theta) \\rightarrow ChiSquared1(n)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/GammaChisquareT.pdf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000724>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Multivariate Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Multivariate Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Sigma"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000808>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Weibull 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Weibull 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lambda^2\\left[\\Gamma\\left(1+\\frac{2}{k}\\right) - \\left(\\Gamma\\left(1+\\frac{1}{k}\\right)\\right)^2\\right]"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001084>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location parameter of Amoroso-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location parameter of Amoroso-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Amoroso1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "a \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000031>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "logit of probability of success of Bernoulli-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "logit of probability of success of Bernoulli-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Bernoulli2.logitProbability"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "logit of probability of success"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "logitProbability"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000686>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Truncated-Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Truncated-Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "TruncatedNormal1.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000971>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between GeneralizedPoisson2 and Generalized Poisson 1 whereby \\\\theta = \\\\mu 1-\\\\delta" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000735> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000712> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\theta = \\mu (1-\\delta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "GeneralizedPoisson2(\\mu,\\delta) \\rightarrow GeneralizedPoisson1(\\theta,\\delta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Yang:2007vn} \\\\
+ProbOnto spec"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001367>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Kumaraswamy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Kumaraswamy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\left(\\frac{a-1}{ab-1}\\right)^{1/a} \\text{ for } a\\geq 1, b\\geq 1, (a,b)\\neq (1,1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001085>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale parameter of Amoroso-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale parameter of Amoroso-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Amoroso1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\theta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\theta \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000334>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Logistic 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Logistic 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000887>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Geometric 1 and Negative Binomial 1 whereby \\\\Sigma X iid" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000782> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000074> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\Sigma X (iid)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Geometric1(p) \\rightarrow NegativeBinomial1(r,p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/GeometricPascal.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001327>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Standard Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Standard Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\pi^2}{3}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000647>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Generalized Gamma 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Generalized Gamma 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "a + b\\Gamma(c+1/k)/\\Gamma(c)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000059>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Beta 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Beta 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "I_x(\\alpha,\\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "Rbeta(x, alpha, beta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000001>
+      a       owl:Class ;
+      rdfs:label "rational number" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000000> .
+
+<http://www.probonto.org/ontology#PROB_k0001413>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Kumaraswamy 1 and Exponential 1 whereby \\\\text{If } X \\\\sim Kumaraswamy1a,1 \\\\text{ then } -\\\\logX \\\\sim Exponential1a" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001360> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000418> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X \\sim Kumaraswamy1(a,1) \\text{ then } -\\log(X) \\sim Exponential1(a)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Kumaraswamy1(a,b) \\rightarrow Exponential1(a)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/Kumaraswamy_distribution}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001216>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{x^\\beta}{\\alpha^\\beta}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "x^beta / alpha^beta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000664>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Triangular 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Triangular 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(a+b+c)/3"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001239>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of YuleSimon1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of YuleSimon1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\rho}{\\rho-1} \\text{ for } \\rho>1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000355>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Logit Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Logit Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\text{ no analytical solution }"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000072>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Half-normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Half-normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\pi - 2}{2 \\theta^2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000685>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Truncated Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Truncated Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\sigma^2 \\Big[ 1 
++ \\frac{ \\frac{a-\\mu}{\\sigma}\\phi(\\frac{a-\\mu}{\\sigma}) - \\frac{b-\\mu}{\\sigma}\\phi(\\frac{b-\\mu}{\\sigma}) }{ \\Phi(\\frac{b-\\mu}{\\sigma}) - \\Phi(\\frac{a-\\mu}{\\sigma}) } 
+- \\Big( \\frac{ \\phi(\\frac{a-\\mu}{\\sigma}) - \\phi(\\frac{b-\\mu}{\\sigma}) }{ \\Phi(\\frac{b-\\mu}{\\sigma}) - \\Phi(\\frac{a-\\mu}{\\sigma}) } \\Big)^2 \\Big]"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000860>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Truncated Normal 1 and Normal 1 whereby a=-\\\\infty, b=\\\\infty" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000681> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "a=-\\infty, b=\\infty"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "TruncatedNormal1(\\mu,\\sigma,a,b) \\rightarrow Normal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{forbes2011statistical}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001081>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Trapezoidal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Trapezoidal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\left\\{ \\begin{array}{rcl}  
+\\dfrac{1}{d+c-a-b}\\dfrac{1}{b-a}(x-a)^2 & a\\leq x < b & \\\\
+\\dfrac{1}{d+c-a-b} (2x-a-b) & b\\leq x < c \\\\ 
+1-\\dfrac{1}{d+c-a-b}\\dfrac{1}{d-c}(d-x)^2 & c\\leq x \\leq d 
+\\end{array}\\right. \\nonumber \\\\"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """CDF1 = 1/(d+c-a-b)*1/(b-a)*(x-a)^2
+CDF2 = 1/(d+c-a-b)*(2*x-a-b)
+CDF3 = 1-1/(d+c-a-b)*1/(d-c)*(d-x)^2"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000749>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "precision matrix of Multivariate-Normal-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "precision matrix of Multivariate-Normal-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateNormal2.precisionMatrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "T"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\text{inverse of the covariance matrix}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "precision matrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "precisionMatrix"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000032>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Gumbel 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Gumbel 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Gumbel1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000033> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000034> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000035> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000036> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000037> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000038> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000039> , <http://www.probonto.org/ontology#PROB_k0000040> .
+
+<http://www.probonto.org/ontology#PROB_k0000721>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Multivariate Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Multivariate Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\text{no analytic expression}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000807>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Weibull 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Weibull 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+\\lambda \\left(\\frac{k-1}{k} \\right)^{\\frac{1}{k}}\\, &k>1\\\\
+0 &k=1\\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000130>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Hypergeometric 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Hypergeometric 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\left \\lfloor \\frac{(n+1)(K+1)}{N+2} \\right \\rfloor"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000027>
+      a       owl:Class ;
+      rdfs:label "hazard function" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000017> .
+
+<http://www.probonto.org/ontology#PROB_k0000932>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 1 and Negative Binomial 2 whereby \\\\tau = 1/r,  \\\\lambda = r1-p/p" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000074> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000105> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\tau = 1/r,  \\lambda = r(1-p)/p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial1(r, p) \\rightarrow NegativeBinomial2(\\lambda, \\tau)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001386>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Folded Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Folded Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "FoldedNormal1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001387> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001388> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001389> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001390> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001392> , <http://www.probonto.org/ontology#PROB_k0001391> .
+
+<http://www.probonto.org/ontology#PROB_c0000081>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has alternate name" .
+
+<http://www.probonto.org/ontology#PROB_k0001326>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Standard Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Standard Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000110>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "Poisson intensity of Negative-Binomial-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Poisson intensity of Negative-Binomial-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial2.rate"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\lambda \\in R, \\lambda > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "Poisson intensity"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "rate"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000335>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Logistic 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Logistic 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001366>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Kumaraswamy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Kumaraswamy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\left(1-2^{-1/b}\\right)^{1/a}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000888>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Gamma 2 and Gamma 1 whereby k=r, \\\\theta = 1 / \\\\mu" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000597> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000571> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "k=r, \\theta = 1 / \\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Gamma2(r,mu) \\rightarrow Gamma1(k,\\theta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001439>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Student's t-distribution 3 and Student's t-distribution 2 whereby \\\\tau=1/\\\\sigma^2" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001091> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000635> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\tau=1/\\sigma^2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StudentT3(\\nu,\\mu,\\sigma) \\rightarrow StudentT2(\\mu,\\tau,k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001410>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Amoroso 1 and Weibull 1 whereby \\\\text{Weibull1}\\\\lambda,k \\\\text{ distribution is a special case of the Amoroso1} a,\\\\theta,\\\\alpha,\\\\beta \\\\text{ distribution when } a = 0, \\\\theta=\\\\lambda, \\\\alpha=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001082> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000800> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{Weibull1}(\\lambda,k) \\text{ distribution is a special case of the Amoroso1} (a,\\theta,\\alpha,\\beta) \\text{ distribution when } a = 0, \\theta=\\lambda, \\alpha=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Amoroso1(a,\\theta,\\alpha,\\beta) \\rightarrow Weibull1(\\lambda,k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{crooks2010amoroso}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000974>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Scaled Inverse Chi-Square and Inverse-Gamma 1 whereby \\\\text{If } X \\\\sim ScaledInverseChiSquare1\\\\nu,\\\\sigma \\\\text{ then } X \\\\sim InverseGamma1\\\\nu/2,\\\\nu \\\\sigma^2 /2" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000509> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000182> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X \\sim ScaledInverseChiSquare1(\\nu,\\sigma) \\text{ then } X \\sim InverseGamma1(\\nu/2,\\nu \\sigma^2 /2)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "ScaledInverseChiSquare1(\\nu,\\sigma) \\rightarrow InverseGamma1(\\alpha,\\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/Scaled_inverse_chi-squared_distribution}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000644>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Generalized Gamma 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Generalized Gamma 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedGamma2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000645> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000646> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000647> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000648> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000649> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "0 < a < x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000652> , <http://www.probonto.org/ontology#PROB_k0000651> , <http://www.probonto.org/ontology#PROB_k0000650> , <http://www.probonto.org/ontology#PROB_k0000653> .
+
+<http://www.probonto.org/ontology#PROB_k0000073>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "inverse scale of Half-normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "inverse scale of Half-normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "HalfNormal1.inverseScale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\theta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\theta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "inverse scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "inverseScale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001219>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\alpha \\beta}{1+\\beta}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001211>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "NA of Makeham-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "NA of Makeham-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Makeham1.delta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\delta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\delta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "delta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001238>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of YuleSimon1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of YuleSimon1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1 - kB(k, \\rho+1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1 - k*beta(k,rho+1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000665>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Triangular 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Triangular 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "c"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000861>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 2 and Negative Binomial 4 whereby r=1/\\\\tau, p = \\\\frac{\\\\tau \\\\lambda}{1 + \\\\tau \\\\lambda}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000105> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000161> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "r=1/\\tau, p = \\frac{\\tau \\lambda}{1 + \\tau \\lambda}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial2(\\lambda, \\tau) \\rightarrow NegativeBinomial4(r,p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """ProbOnto spec \\\\
+\\cite{cameron2013regression}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000684>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Truncated Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Truncated Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu + \\frac{ \\phi(\\frac{a-\\mu}{\\sigma}) - \\phi(\\frac{b-\\mu}{\\sigma}) }{ \\Phi(\\frac{b-\\mu}{\\sigma}) - \\Phi(\\frac{a-\\mu}{\\sigma}) } \\sigma"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000071>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Half-normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Half-normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1/\\theta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000806>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Weibull 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Weibull 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lambda(\\log(2))^{1/k}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000722>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Multivariate Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Multivariate Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001385>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Standard-Two-Sided-Power-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Standard-Two-Sided-Power-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StandardTwoSidedPower1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "n"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "n > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000931>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Log-Normal 6 and Log-Normal 2 whereby \\\\mu=\\\\logm, 
+ v=\\\\log\\\\sigma_g^2""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000553> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000453> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """\\mu=\\log(m), 
+ v=\\log(\\sigma_g^2)"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal6(m,\\sigma_g) \\rightarrow LogNormal2(\\mu,v)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000579>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Gamma-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Gamma-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Gamma1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\theta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\theta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001082>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Amoroso 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Amoroso 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Amoroso1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001083> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\geq a \\text{ if } \\theta > 0, x \\leq a \\text{ if } \\theta < 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001085> , <http://www.probonto.org/ontology#PROB_k0001087> , <http://www.probonto.org/ontology#PROB_k0001086> , <http://www.probonto.org/ontology#PROB_k0001084> .
+
+<http://www.probonto.org/ontology#PROB_k0000033>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Gumbel 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Gumbel 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{e^{-e^{-\\frac{x-\\mu}{\\beta}}} e^{-\\frac{x-\\mu}{\\beta}}}{\\beta}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(exp(-exp(-(x-mu)/beta)) * exp(-(x-mu)/beta))/beta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000026>
+      a       owl:Class ;
+      rdfs:label "survival function" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000017> .
+
+<http://www.probonto.org/ontology#PROB_k0000356>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Logit Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Logit Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\exp(\\mu)}{1+\\exp(\\mu)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001325>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Standard Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Standard Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000080>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has abbreviation" .
+
+<http://www.probonto.org/ontology#PROB_k0000559>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Log-Normal 6" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Log-Normal 6"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "m^2 e^{\\log^2(\\sigma_g)} [e^{\\log^2(\\sigma_g)}-1]"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001411>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Kumaraswamy 1 and Standard Uniform 1 whereby \\\\text{If } X \\\\sim Kumaraswamy11,1 \\\\text{ then } X \\\\sim StandardUniform1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001360> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000587> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X \\sim Kumaraswamy1(1,1) \\text{ then } X \\sim StandardUniform1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Kumaraswamy1(a,b) \\rightarrow StandardUniform1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/Kumaraswamy_distribution}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001365>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Kumaraswamy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Kumaraswamy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{b\\Gamma(1+\\tfrac{1}{a})\\Gamma(b)}{\\Gamma(1+\\tfrac{1}{a}+b)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000336>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Logistic 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Logistic 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001438>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Beta Negative Binomial1 and Negative Binomial 1 whereby \\\\text{If } X \\\\sim \\\\text{NegativeBinomial1n,p and } p \\\\sim \\\\text{Beta1}\\\\alpha,\\\\beta \\\\text{ then } X \\\\sim \\\\text{NegativeBinomial1}\\\\alpha,\\\\beta,n" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001167> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000074> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X \\sim \\text{NegativeBinomial1(n,p) and } p \\sim \\text{Beta1(}\\alpha,\\beta \\text{) then } X \\sim \\text{NegativeBinomial1}(\\alpha,\\beta,n)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "BetaNegativeBinomial1(\\alpha,\\beta,n) \\rightarrow NegativeBinomial1(r,p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/PascalBetapascal.pdf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000889>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Beta-binomial 1 and Uniform Discrete 2 whereby \\\\alpha=1, \\\\beta=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000090> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000750> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\alpha=1, \\beta=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "BetaBinomial1(n,\\alpha,\\beta) \\rightarrow UniformDiscrete2(n)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/BetabinomialRectangular.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000973>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label """relationship between Conway-Maxwell-Poisson 1 and Negative Binomial 1 whereby \\\\text{ For } \\\\nu=0 \\\\text{ and } \\\\lambda<1 \\\\text{ the sum of Conway-Maxwell-Poisson distributed variables}\\\\\\\\
+\\\\text{reduces to the sum of geometric variables, which follows a Negative Binomial distribution with parameters}\\\\\\\\  n \\\\text{ and } 1-\\\\lambda""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000323> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000074> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """\\text{ For } \\nu=0 \\text{ and } \\lambda<1 \\text{ the sum of Conway-Maxwell-Poisson distributed variables}\\\\
+\\text{reduces to the sum of geometric variables, which follows a Negative Binomial distribution with parameters}\\\\  n \\text{ and } 1-\\lambda"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "ConwayMaxwellPoisson1(\\lambda,\\nu) \\rightarrow NegativeBinomial1(r,p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{shmueli2005useful}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000645>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Generalized Gamma 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Generalized Gamma 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{k (x-a)^{kc-1}}{b^{kc}\\Gamma(c)}\\exp\\Big[-\\Big(\\frac{x-a}{b}\\Big)^k\\Big]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(k*(x-a)^(k*c-1)) / (b^(k*c)*gamma(c)) * exp( -((x-a)/b)^k )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001210>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Makeham 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Makeham 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\text{mathematically intractable}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001218>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1- \\frac{x^\\beta}{\\alpha^\\beta}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1- x^beta / alpha^beta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000709>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Uniform 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\tfrac{1}{12} (b-a)^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001345>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Muth 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Muth 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(e^{\\kappa x}-\\kappa) e^{\\left[-\\frac{e^{\\kappa x}}{\\kappa} + \\kappa x + \\frac1{\\kappa} \\right]}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(exp(kappa*x)-kappa)*exp( -exp(kappa*x)/x + kappa*x + 1/kappa )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001099>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Arcsine 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Arcsine 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{2}{\\sqrt{x(1-x)} (\\pi - 2 \\arcsin\\left(2x -1\\right))}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "2/(sqrt(x*(1-x))*(pi - 2 * asin(2*x -1)))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001230>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Power-Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Power-Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "PowerNormal1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001231> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001232> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001234> , <http://www.probonto.org/ontology#PROB_k0001235> , <http://www.probonto.org/ontology#PROB_k0001233> .
+
+<http://www.probonto.org/ontology#PROB_k0000113>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Wishart 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Wishart 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "|R|^{k/2}|x|^{(k-p-1)/2}e^{-\\frac{1}2\\,tr(Rx)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000198>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Zero-inflated Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Zero-inflated Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+\\pi + (1-\\pi) e^{-\\lambda}& \\text{for } k = 0 \\\\ 
+(1-\\pi) e^{-\\lambda} \\frac{\\lambda^k}{k!} & \\text{for } k > 0
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """PMF1=pi + (1-pi)*exp(-lambda) # if k=0
+PMF2=(1-pi)*exp(-lambda) * lambda^k/factorial(k) # if k>0"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001270>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Dagum 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Dagum 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{a p}{x} \\left( \\frac{(\\tfrac{x}{b})^{a p}}{\\left((\\tfrac{x}{b})^a + 1 \\right)^{p+1}} \\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "a*p/x * (x/b)^(a*p) / ((x/b)^a + 1)^(p+1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000282>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Cauchy-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Cauchy-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Cauchy1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\gamma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\gamma \\in  R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000965>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 4 and Log-Normal 2 whereby \\\\mu = \\\\logm, v = \\\\logcv^2+1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000500> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000453> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = \\log(m), v = \\log(cv^2+1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal4(m,cv) \\rightarrow LogNormal2(\\mu,v)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000750>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Uniform Discrete 2" , "Rectangular Discrete 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Uniform Discrete 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "UniformDiscrete2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000751> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000752> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0000754> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0000753> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000755> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000756> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,1,2,\\dots,n\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000757> .
+
+<http://www.probonto.org/ontology#PROB_k0001299>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale parameter of Johnson-SB-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale parameter of Johnson-SB-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSB1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001146>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Noncentral F 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Noncentral F 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{n}{m} \\frac{m+lambda}{n-2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000411>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\lambda^k}{k!}e^{-\\lambda}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "lambda^k/factorial(k) * exp(-lambda)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000776>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Von Mises 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Von Mises 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000177>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Birnbaum-Saunders 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Birnbaum-Saunders 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "BirnbaumSaunders1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000178> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000179> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000181> , <http://www.probonto.org/ontology#PROB_k0000180> .
+
+<http://www.probonto.org/ontology#PROB_k0000013>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Gompertz 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Gompertz 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\left(1/b\\right)\\log\\left[\\left(-1/\\eta\\right) \\log\\left(1/2\\right)+1\\right]"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000945>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 5 and Log-Normal 1 whereby \\\\mu = \\\\mu, \\\\sigma = 1 / \\\\sqrt{\\\\tau}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000526> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000428> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = \\mu, \\sigma = 1 / \\sqrt{\\tau}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal5(\\mu,\\tau) \\rightarrow LogNormal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000439>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Poisson 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Poisson 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\gamma(\\lfloor k+1 \\rfloor,\\exp(\\alpha))}{\\lfloor k \\rfloor!}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "Igamma(floor(k+1), exp(alpha), lower=F) / factorial(floor(k))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000157>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Inverse Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Inverse Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "k (1-p) / (2p-1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000352>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Logit Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Logit Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogitNormal1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000353> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000354> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000355> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000356> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000357> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000358> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000360> , <http://www.probonto.org/ontology#PROB_k0000359> .
+
+<http://www.probonto.org/ontology#PROB_k0000281>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Cauchy-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Cauchy-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Cauchy1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "x_0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "x_0 \\in  R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001258>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Sinh-Arcsinh 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Sinh-Arcsinh 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\frac{c}{\\sqrt{2\\pi} \\sigma (1+z^2)^{1/2}} e^{-r^2/2}\\\\
+r = \\frac12 \\left(\\exp[\\tau \\sinh^{-1}(z)] - \\exp[-\\nu \\sinh^{-1}(z)]\\right)\\\\
+c = \\frac12 \\left( \\tau \\exp[\\tau \\sinh^{-1}(z)] + \\nu \\exp[-\\nu \\sinh^{-1}(z)] \\right)\\\\
+z = (x-\\mu)/\\sigma"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """cfunc(x,mu,sigma,nu,tau) / (sqrt(2*pi) * sigma * (1+zfunc(x,mu,sigma)^2)^(1/2)) * exp(-rfunc(x,mu,sigma,nu,tau)^2/2)
+rfunc = function(x,mu,sigma,nu,tau) { 1/2 * ( exp(tau * asinh(zfunc(x,mu,sigma))) - exp(-nu * asinh(zfunc(x,mu,sigma))) ) }
+cfunc = function(x,mu,sigma,nu,tau) { 1/2 * ( tau * exp(tau * asinh(zfunc(x,mu,sigma))) + nu * exp(-nu * asinh(zfunc(x,mu,sigma))) ) }
+zfunc = function(x,mu,sigma) { (x-mu)/sigma }"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001058>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Half-normal 2 and Half-normal 1 whereby \\\\mu=0, \\\\sigma=\\\\sqrt{\\\\pi} / \\\\theta \\\\sqrt{2}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000982> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000068> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu=0, \\sigma=\\sqrt{\\pi} / (\\theta \\sqrt{2})"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "HalfNormal2(\\mu,\\sigma) \\rightarrow HalfNormal1(\\theta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000227>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Categorical Ordered 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Categorical Ordered 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "E([x=i]) = p_i, \\text{this is the mean of the Iverson bracket } [x=i] \\text{ and not the mean of } x"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000730>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Uniform Discrete 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Uniform Discrete 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(a+b)/2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000390>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Pareto-Type-II" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Pareto-Type-II"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ParetoTypeII1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\lambda \\in R^+"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001098>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Arcsine 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Arcsine 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{2}{\\pi}\\arcsin\\left(\\sqrt x \\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "2/pi*arcsin(sqrt(x))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000392>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Erlang 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Erlang 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Erlang1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000393> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000394> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0000396> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0000395> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000397> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000398> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000399> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              """x \\in [0,+\\infty) \\text{ (Forbes)}, 
+x \\in (0,+\\infty) \\text{ (Leemis)}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000400> , <http://www.probonto.org/ontology#PROB_k0000401> .
+
+<http://www.probonto.org/ontology#PROB_k0000197>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Zero-inflated Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Zero-inflated Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ZeroInflatedPoisson1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000198> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000199> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000200> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000201> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000203> , <http://www.probonto.org/ontology#PROB_k0000202> .
+
+<http://www.probonto.org/ontology#PROB_k0000410>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Poisson1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000411> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000412> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000413> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000414> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000415> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000416> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000417> .
+
+<http://www.probonto.org/ontology#PROB_k0001231>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Power-Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Power-Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\frac{1}K \\frac{1}{\\sqrt{2 \\pi} \\sigma} x^{\\lambda-1} \\exp\\left[-\\frac12 \\left(\\frac{x^{(\\lambda)}-\\mu}{\\sigma}\\right)^2 \\right]
+\\text{ with }
+x^{(\\lambda)}=\\begin{cases}
+(x^\\lambda - 1)/\\lambda & \\text{for } \\lambda \\neq 0 \\\\ 
+\\log(x) & \\text{for } \\lambda = 0
+\\end{cases}; \\quad 
+K=\\begin{cases}
+\\Phi(T) & \\text{for } \\lambda > 0 \\\\ 
+1 & \\text{for } \\lambda = 0 \\\\
+\\Phi(-T) & \\text{for } \\lambda < 0
+\\end{cases}; \\quad 
+T = 1/(\\lambda \\sigma) + \\mu/\\sigma"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """1/(K(lambda,mu,sigma) * sqrt(2*pi) * sigma) * x^(lambda-1) * exp(- 1/2 * ((BCtrafo(x,lambda)-mu) / sigma)^2 )
+BCtrafo = function(x,lambda) {
+  (x^lambda - 1) / lambda
+}
+erf <- function(x) { 2 * pnorm(x * sqrt(2)) - 1 }
+PHI <- function(x) { 1/2 * (1 + erf(x/(sqrt(2)))) }
+Tfunc <- function(lambda,mu,sigma) { 1/(lambda*sigma) + mu/sigma }
+K = function(lambda,mu,sigma) {
+  if (lambda > 0) {
+    K = PHI(Tfunc(lambda,mu,sigma))
+  } else if (lambda==0) {
+    K = 1
+  } else {
+    K = PHI(-Tfunc(lambda,mu,sigma))
+  }
+}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001298>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location parameter of Johnson-SB-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location parameter of Johnson-SB-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSB1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000966>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Generalized Poisson 1 and GeneralizedPoisson2 whereby \\\\mu = \\\\theta / 1-\\\\delta" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000712> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000735> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = \\theta / (1-\\delta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "GeneralizedPoisson1(\\theta,\\delta) \\rightarrow GeneralizedPoisson2(\\mu,\\delta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Yang:2007vn} \\\\
+ProbOnto spec"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001145>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Noncentral F 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Noncentral F 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\int_0^x f(x),
+\\text { with f the PDF}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "cumsum(PDF*rep(stepSize,length(PDF)))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000636>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Student's t-distribution 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Student's t-distribution 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\Gamma \\left(\\frac{k+1}{2} \\right)} {\\Gamma \\left(\\frac{k}{2} \\right)} \\sqrt{\\frac{\\tau}{k\\pi}}\\left[1+\\frac{\\tau}{k}(x-\\mu)^2 \\right]^{-\\frac{k+1}{2}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "gamma((k+1)/2)/gamma(k/2)*sqrt(tau/(k*pi))*(1+tau/k*(x-mu)^2)^(-(k+1)/2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000283>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Double Exponential 2"^^<en> , "Laplace 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Laplace 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Laplace2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000284> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000285> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000286> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000287> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000288> , <http://www.probonto.org/ontology#PROB_k0000289> .
+
+<http://www.probonto.org/ontology#PROB_k0001346>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Muth 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Muth 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1-e^{\\left[-\\frac{e^{\\kappa x}}{\\kappa} + \\kappa x + \\frac1{\\kappa} \\right]}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1-exp( -exp(kappa*x)/x + kappa*x + 1/kappa )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000178>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Birnbaum-Saunders 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Birnbaum-Saunders 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\sqrt{2\\pi}}\\exp\\Big[-\\frac{(\\sqrt{x/\\beta}-\\sqrt{\\beta/x})^2}{2\\gamma^2}\\Big]\\Big[\\frac{\\sqrt{x/\\beta}+\\sqrt{\\beta/x}}{2\\gamma x}\\Big]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """1/(sqrt(2*pi))* exp( -(sqrt(x/beta) - sqrt(beta/x))^2 / (2*gamma^2) ) * ( sqrt(x/beta) + sqrt(beta/x) ) / (2*gamma*x)
+"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000775>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Von Mises 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Von Mises 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{2\\pi I_0(\\kappa)}\\Big[ x I_0(\\kappa) + 2\\sum_{j=0}^{\\infty}I_j(\\kappa)\\frac{sin(j(x-mu))}{j}\\Big]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """1/(2*pi*besselI(kappa,0,expon.scaled=FALSE)) 
+* ( x*besselI(kappa, 0, expon.scaled = FALSE) + 2*sumFromTo(x,mu,kappa,0,infty))
+# with
+sumFromTo = function(x,mu,kappa,fromValue,toValue) {
+    sigma=0;
+    for(i in fromValue:toValue) {
+      sigma = sigma + besselI(kappa,i,expon.scaled=FALSE) * sin(i*(x-mu))/i
+    }
+  return(sigma)
+}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000351>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "concentration of Dirichlet-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "concentration of Dirichlet-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Dirichlet1.concentration"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha_1, \\cdots, \\alpha_K"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha_1, \\cdots, \\alpha_K, \\alpha_i > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "concentration"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "concentration"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000012>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Gompertz 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Gompertz 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\exp\\left(-\\eta\\left(e^{bx}-1 \\right)\\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp(-eta*(exp(b*x)-1))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000946>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 4 and Log-Normal 6 whereby m = m, \\\\sigma_g=\\\\exp\\\\!\\\\big\\\\sqrt{\\\\logcv^2+1}\\\\big" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000500> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000553> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "m = m, \\sigma_g=\\exp\\!\\big(\\sqrt{\\log(cv^2+1)}\\big)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal4(m,cv) \\rightarrow LogNormal6(m,\\sigma_g)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001259>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Sinh-Arcsinh-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Sinh-Arcsinh-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "SinhArcsinh1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001059>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Trapezoidal 1 and Triangular 1 whereby b=c" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001044> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000661> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "b=c"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Trapezoidal1(a,b,c,d) \\rightarrow Triangular1(a,b,c)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{Garvey:2000yq}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000438>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Poisson 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Poisson 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac1{k!}\\exp\\big(k \\alpha - \\exp(\\alpha)\\big)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/factorial(k) * exp(k*alpha - exp(alpha))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000158>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Inverse Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Inverse Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "k p (1-p) / (2p - 1)^3"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000226>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Categorical Ordered 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Categorical Ordered 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+    0 & \\text{for }x<1 \\\\
+    \\sum_{j=1}^i p_j & \\text{for }x \\in [i,i+1) \\\\
+    1 & \\text{for }x \\geq k
+    \\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000391>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "tail index of Pareto-Type-II" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "tail index of Pareto-Type-II"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ParetoTypeII1.tailIndex"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha > 0, \\alpha \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "tail index"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "tailIndex"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000752>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Uniform Discrete 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Uniform Discrete 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{k+1}{n+1}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(k+1)/(n+1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000859>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label "relationship between Zero-Inflated Negative Binomial 1 and Zero-inflated Poisson 1 whereby \\\\tau \\\\rightarrow 0" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000142> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000197> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\tau \\rightarrow 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "ZeroInflatedNegativeBinomial1(\\lambda,\\tau,p0) \\rightarrow ZeroInflatedPoisson1(\\lambda,\\pi)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{Troconiz:2009fv}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000300>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Chi-squared 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Chi-squared 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{2^{\\frac{k}{2}}\\Gamma\\left(\\frac{k}{2}\\right)}\\; x^{\\frac{k}{2}-1} e^{-\\frac{x}{2}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/( 2^k/2 * gamma(k/2) ) *  x^(k/2-1) * exp(-x/2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000111>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "overdispersion of Negative-Binomial-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "overdispersion of Negative-Binomial-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial2.overdispersion"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\tau"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\tau \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "overdispersion"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "overdispersion"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000196>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "inverse scale of Negative-Binomial-5" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "inverse scale of Negative-Binomial-5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial5.inverseScale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta \\in R^+"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "inverse scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "inverseScale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000879>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Generalized Negative Binomial 1 and Negative Binomial 4 whereby \\\\beta=1 \\\\text{ and set } m=r, \\\\theta=p" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000690> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000161> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\beta=1 \\text{ and set } m=r, \\theta=p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "GeneralizedNegativeBinomial1(\\theta,\\beta,m) \\rightarrow NegativeBinomial4(r,p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{Consul:2006qf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000039>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Gumbel-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Gumbel-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Gumbel1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in  R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000838>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Generalized Gamma 2 and Chi-squared 1 whereby a=0, b=2, c=k_{ChiSquare1}/2,k=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000644> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000299> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "a=0, b=2, c=k_{ChiSquare1}/2,k=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "GeneralizedGamma2(a,b,c,k) \\rightarrow ChiSquared1(k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{forbes2011statistical}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000774>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Von Mises 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Von Mises 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\exp(\\kappa \\cos(x-\\mu))}{2\\pi I_0(\\kappa)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp(kappa * cos(x-mu)) / (2*pi * besselI(kappa, 0, expon.scaled = FALSE))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000963>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Logistic 2 and Log-Logistic 1 whereby \\\\alpha=1/\\\\lambda, \\\\beta=\\\\kappa" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000402> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000377> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\alpha=1/\\lambda, \\beta=\\kappa"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogLogistic2(\\lambda,\\kappa) \\rightarrow LogLogistic1(\\alpha,\\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001297>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Johnson-SB-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Johnson-SB-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSB1.shape2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\delta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\delta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001347>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Muth 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Muth 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "e^{\\kappa x} - \\kappa"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp(kappa*x) - kappa"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000175>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "dispersion of Zero-Inflated-Generalized-Poisson-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "dispersion of Zero-Inflated-Generalized-Poisson-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ZeroInflatedGeneralizedPoisson1.dispersion"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha > -1, \\alpha \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "dispersion"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "dispersion"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000413>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lambda"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001144>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Noncentral F 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Noncentral F 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "e^{-\\frac\\lambda2} \\sum_{r=0}^{\\infty}\\frac1{r!}\\left(\\frac{\\lambda}{2}\\right)^r \\frac{\\Gamma\\left(\\frac{m+n}{2}+r\\right)}{\\Gamma\\left(\\frac{m}{2}+r\\right)\\Gamma\\left(\\frac{n}{2}\\right)} \\left(\\frac{m}{n}\\right)^{\\frac{m}{2}+r} \\frac{(F')^{\\frac{m}{2}-1+r}}{\\left(1+\\frac{mF'}{n}\\right)^{\\frac12 (m+n)+r}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """PDF = function(x,lambda,m,n,lowerLimit,upperLimit) { exp(-lambda/2) * PDFsum(x,lambda,m,n,lowerLimit,upperLimit) }
+PDFsum = function(x,lambda,m,n,fromValue,toValue) {
+  PDF=array(0,length(x));
+  for(j in 1:length(x)) {
+    for(r in fromValue:toValue) {
+      PDF[j] = PDF[j] + 1/factorial(r)*(lambda/2)^r*gamma((m+n)/2+r)/gamma(m/2+r)/gamma(n/2) * (m/n)^(m/2+r) * x[j]^(m/2-1+r) / (1+m*x[j]/n)^(1/2*(m+n)+r)
+    }
+  }
+  return(PDF)
+}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000639>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Student's t-distribution 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Student's t-distribution 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu \\text{ for } k > 1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000818>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Log-Normal 3 and Log-Normal 4 whereby m = m, 
+cv = \\\\sqrt{\\\\exp\\\\sigma^2 - 1}""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000478> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000500> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """m = m, 
+cv = \\sqrt{\\exp(\\sigma^2) - 1}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal3(m,\\sigma) \\rightarrow LogNormal4(m,cv)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000155>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Inverse Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Inverse Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{k \\; \\Gamma(2x + k)}{\\Gamma(x+1) \\;\\Gamma(x + k + 1)}  \\; p^{k+x} (1-p)^x "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(k * gamma(2*x+k)) / (gamma(x+1) * gamma(x+k+1)) * p^(x+k) * (1-p)^x"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000139>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Negative Binomial 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Negative Binomial 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu + \\mu^2 / \\phi"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000011>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Gompertz 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Gompertz 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "b\\eta\\exp(-b x)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "b *eta * exp(-b*x)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000350>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Dirichlet 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Dirichlet 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "Var[X_i] = \\frac{\\alpha_i (\\alpha_0-\\alpha_i)}{\\alpha_0^2 (\\alpha_0+1)} \\quad \\text{where} \\quad \\alpha_0 = \\sum_{i=1}^K\\alpha_i; \\quad Cov[X_i,X_j] = \\frac{- \\alpha_i \\alpha_j}{\\alpha_0^2 (\\alpha_0+1)}~~(i\\neq j)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000019>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Multivariate-Student-T-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Multivariate-Student-T-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateStudentT2.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu = [\\mu_1, \\dots, \\mu_d]^T, \\mu_i \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000943>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label "relationship between F 1 and Chi-squared 1 whereby \\\\text{If } X \\\\sim F1n_1,n_2 \\\\text{, the limiting distribution of } n_1X \\\\text{ as } n_2 \\\\rightarrow \\\\infty \\\\text{ is} \\\\\\\\ \\\\text{ the chi-square distribution with } n_1 \\\\text{ degrees of freedom}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000492> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000299> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X \\sim F1(n_1,n_2) \\text{, the limiting distribution of } n_1X \\text{ as } n_2 \\rightarrow \\infty \\text{ is} \\\\ \\text{ the chi-square distribution with } n_1 \\text{ degrees of freedom}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "F1(n_1,n_2) \\rightarrow ChiSquared1(n)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/FChisquare.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000732>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Uniform Discrete 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Uniform Discrete 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{(b-a+1)^2 -1}{12}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000225>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Categorical Ordered 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Categorical Ordered 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "p(x=i)=p_i"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001256>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degrees of freedom of Inverse-Chi-Square" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degrees of freedom of Inverse-Chi-Square"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "InverseChiSquare1.degreesOfFreedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\nu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\nu \\in R^+"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degrees of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "degreesOfFreedom"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000112>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Wishart 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Wishart 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Wishart2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000113> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "X"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "X(p \\times p) - \\text{symmetric, positive definite matrix}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000115> , <http://www.probonto.org/ontology#PROB_k0000116> .
+
+<http://www.probonto.org/ontology#PROB_k0000195>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Negative-Binomial-5" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Negative-Binomial-5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial5.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha \\in R^+"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000773>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Von Mises 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Von Mises 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "VonMises1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000774> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000775> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000776> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000777> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000778> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000779> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in \\text{any interval of length } 2\\pi"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000781> , <http://www.probonto.org/ontology#PROB_k0000780> .
+
+<http://www.probonto.org/ontology#PROB_k0000878>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Inverse Gaussian 1 and Chi-squared 1 whereby X \\\\sim InverseGaussian1\\\\lambda,\\\\mu \\\\text{ and }  Y = \\\\lambda X-\\\\mu^2 / \\\\mu^2 X \\\\Rightarrow Y \\\\sim ChiSquared1k" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000212> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000299> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "X \\sim InverseGaussian1(\\lambda,\\mu) \\text{ and }  Y = \\lambda (X-\\mu)^2 / (\\mu^2 X) \\Rightarrow Y \\sim ChiSquared1(k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "InverseGaussian1(\\lambda,\\mu) \\rightarrow ChiSquared1(k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/InversegaussianChisquare.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001143>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Noncentral F 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Noncentral F 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NoncentralF1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001144> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001145> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001146> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001147> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "F'=\\frac{x_1/m}{x_2/n} \\text{ with } x_1 \\sim ChiSquared1(m), x_2 \\sim ChiSquared1(n)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "F' \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001150> , <http://www.probonto.org/ontology#PROB_k0001148> , <http://www.probonto.org/ontology#PROB_k0001149> .
+
+<http://www.probonto.org/ontology#PROB_k0000038>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Gumbel 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Gumbel 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\pi^2}{6} \\beta^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000839>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 3 and Negative Binomial 5 whereby \\\\alpha = \\\\phi, \\\\beta = \\\\phi / \\\\mu" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000135> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000190> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\alpha = \\phi, \\beta = \\phi / \\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial3(\\mu, \\phi) \\rightarrow NegativeBinomial5(\\alpha, \\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000176>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "probability of zero of Zero-Inflated-Generalized-Poisson-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "probability of zero of Zero-Inflated-Generalized-Poisson-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ZeroInflatedGeneralizedPoisson1.probabilityOfZero"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "p0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "0<p0<1, p0 \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "probability of zero"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "probabilityOfZero"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001296>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Johnson-SB-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Johnson-SB-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSB1.shape1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\gamma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\gamma \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001340>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Johnson-SN-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Johnson-SN-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSN1.shape1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\gamma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\gamma \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000964>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Poisson 1 and Poisson 2 whereby \\\\alpha = \\\\log\\\\lambda" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000410> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000437> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\alpha = \\log(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Poisson1(\\lambda) \\rightarrow Poisson2(\\alpha)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{stan-manual:2015b}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001348>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Muth 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Muth 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "e^{\\left[-\\frac{e^{\\kappa x}}{\\kappa} + \\kappa x + \\frac1{\\kappa} \\right]}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp( -exp(kappa*x)/x + kappa*x + 1/kappa )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000638>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Student's t-distribution 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Student's t-distribution 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000412>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\gamma(\\lfloor k+1 \\rfloor,\\lambda)}{\\lfloor k \\rfloor!}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "Igamma(floor(k+1), lambda, lower=F) / factorial(floor(k))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000751>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Uniform Discrete 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Uniform Discrete 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1/(n+1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(n+1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000280>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "undefined"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000010>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Gompertz 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Gompertz 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1-\\exp\\left(-\\eta\\left(e^{bx}-1 \\right)\\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1-exp(-eta*(exp(b*x)-1))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000944>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 6 and Negative Binomial 3 whereby \\\\mu = \\\\exp\\\\eta" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000217> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000135> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = \\exp(\\eta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial6(\\eta,\\phi) \\rightarrow NegativeBinomial3(\\mu,\\phi)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{stan-manual:2015b}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001320>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale parameter of Johnson-SL-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale parameter of Johnson-SL-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSL1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000819>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between GeneralizedPoisson2 and Poisson 1 whereby \\\\delta = 0, \\\\lambda=\\\\mu" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000735> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000410> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\delta = 0, \\lambda=\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "GeneralizedPoisson2(\\mu,\\delta) \\rightarrow Poisson1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{Plan:2014kq}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000731>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Uniform Discrete 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Uniform Discrete 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(a+b)/2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000858>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Normal 2 and Normal 1 whereby \\\\mu = \\\\mu, 
+\\\\sigma = \\\\sqrt{v}""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000265> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """\\mu = \\mu, 
+\\sigma = \\sqrt{v}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Normal2(\\mu,v) \\rightarrow Normal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000224>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Categorical Ordered 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Categorical Ordered 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "CategoricalOrdered1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000225> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000226> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000227> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000228> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000229> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000230> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in \\{1,\\dots,k\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000231> .
+
+<http://www.probonto.org/ontology#PROB_k0001257>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Sinh-Arcsinh 1" , "SHASH"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Sinh-Arcsinh 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "SinhArcsinh1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001258> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001261> , <http://www.probonto.org/ontology#PROB_k0001259> , <http://www.probonto.org/ontology#PROB_k0001262> , <http://www.probonto.org/ontology#PROB_k0001260> .
+
+<http://www.probonto.org/ontology#PROB_k0000117>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Binomial1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000118> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000119> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000120> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000121> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000122> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000123> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,\\dots,n\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000125> , <http://www.probonto.org/ontology#PROB_k0000124> .
+
+<http://www.probonto.org/ontology#PROB_k0001341>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Johnson-SN-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Johnson-SN-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSN1.shape2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\delta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\delta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001349>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Muth 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Muth 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001295>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Johnson SB 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Johnson SB 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+\\frac12 \\text{erfc}\\left[-\\frac{\\gamma + \\delta \\,\\log\\left[\\frac{x-\\mu}{-x+\\mu+\\sigma}\\right]}{\\sqrt{2}}\\right] & \\text{for } \\mu < x < \\mu + \\frac{\\sigma}{2} \\\\ 
+\\frac12\\left(1+  \\text{erf}\\left[\\frac{\\gamma + \\delta \\,\\log\\left[\\frac{x-\\mu}{-x+\\mu+\\sigma}\\right]}{\\sqrt{2}}\\right] \\right) & \\text{for }\\mu + \\frac{\\sigma}{2} \\le x < \\mu + \\sigma
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """CDF1=1/2*erfc(-(gamma+delta*log((x-mu)/(-x+mu+sigma)))/sqrt(2))
+CDF2=1/2*(1+erf((gamma+delta*log((x-mu)/(-x+mu+sigma)))/sqrt(2)))"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000415>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lceil\\lambda\\rceil - 1, \\lfloor\\lambda\\rfloor"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000203>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "probability of extra zeros of Zero-inflated-Poisson-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "probability of extra zeros of Zero-inflated-Poisson-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ZeroInflatedPoisson1.probabilityOfZero"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\pi"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "0<\\pi<1, \\pi \\in  R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "probability of extra zeros"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "probabilityOfZero"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001234>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Power-Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Power-Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "PowerNormal1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000194>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Negative Binomial 5" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Negative Binomial 5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\alpha/\\beta^2 (\\beta+1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000754>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Uniform Discrete 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Uniform Discrete 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{n-k}{n+1}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(n-k)/(n+1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001254>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Inverse Chi-Square" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Inverse Chi-Square"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\nu + 2} "^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000857>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Standard Normal 1 and Chi-squared 1 whereby \\\\Sigma X^2" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000562> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000299> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\Sigma X^2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StandardNormal1(0,1) \\rightarrow ChiSquared1(k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/StandardnormalChisquare.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000193>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Negative Binomial 5" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Negative Binomial 5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\alpha / \\beta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000153>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "logit of success probability in each trial of Binomial-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "logit of success probability in each trial of Binomial-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Binomial2.logitProbability"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "logit of success probability in each trial"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "logitProbability"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000435>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of logx of Log-Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of log(x) of Log-Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal1.meanLog"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean of log(x)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "meanLog"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000941>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Log-Normal 6 and Log-Normal 3 whereby m = m,  
+\\\\sigma=\\\\log\\\\sigma_g""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000553> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000478> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """m = m,  
+\\sigma=\\log(\\sigma_g)"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal6(m,\\sigma_g) \\rightarrow LogNormal3(m,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000017>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Multivariate Student T 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Multivariate (Student) T 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\Gamma((k+d)/2)}{\\Gamma(k/2) k^{d/2} \\pi^{d/2}}|T|^{1/2} \\Big[ 1 + \\frac{1}{k}(x-\\mu)' T (x-\\mu) \\Big]^{-(k+d)/2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000816>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Scaled Inverse Chi-Square and Scaled Inverse Chi-Square whereby \\\\text{If } X \\\\sim ScaledInverseChiSquare1\\\\nu,\\\\sigma \\\\text{ then } kX \\\\sim ScaledInverseChiSquare1\\\\nu, k\\\\sigma" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000509> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000509> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X \\sim ScaledInverseChiSquare1(\\nu,\\sigma) \\text{ then } kX \\sim ScaledInverseChiSquare1(\\nu, k\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "ScaledInverseChiSquare1(\\nu,\\sigma) \\rightarrow ScaledInverseChiSquare1(\\nu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/Scaled_inverse_chi-squared_distribution}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001275>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Dagum 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Dagum 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+-\\frac{b^2}{a^2} \\left(2 a \\frac{\\Gamma\\left(-\\tfrac{2}{a}\\right) \\, \\Gamma\\left(\\tfrac{2}{a} + p\\right)}{\\Gamma\\left(p\\right)} + \\left( \\frac{\\Gamma\\left(-\\tfrac{1}{a}\\right) \\Gamma\\left(\\tfrac{1}{a} + p\\right)}{\\Gamma\\left(p\\right)} \\right)^2\\right) & \\text{if}\\ a>2    \\\\
+\\text{Indeterminate} & \\text{otherwise}
+\\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001369>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Kumaraswamy-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Kumaraswamy-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Kumaraswamy1.shape2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "b > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000969>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Poisson 2 and Poisson 1 whereby \\\\lambda = \\\\exp\\\\alpha" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000437> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000410> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\lambda = \\exp(\\alpha)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Poisson2(\\alpha) \\rightarrow Poisson1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{stan-manual:2015b}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000223>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "index parameter of Negative-Binomial-6" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "index parameter of Negative-Binomial-6"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial6.dispersion"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\phi"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\phi \\in R, \\phi > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "index parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "dispersion"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000080>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "number of successes of Negative-Binomial-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "number of successes of Negative-Binomial-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial1.numberOfSuccesses"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "r"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "r > 0, r \\in N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "number of successes"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "numberOfSuccesses"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001342>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location parameter of Johnson-SN-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location parameter of Johnson-SN-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSN1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000779>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Von Mises 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Von Mises 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1 - \\frac{I_1(\\kappa)}{I_1(0)} \\text{ (circular variance)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000414>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\approx\\lfloor\\lambda+1/3-0.02/\\lambda\\rfloor"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000118>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "{n \\choose k}\\, p^k (1-p)^{n-k}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "choose(n,k) * p^k*(1-p)^(n-k)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001294>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Johnson SB 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Johnson SB 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{e^{-\\frac12 \\left( \\gamma + \\delta \\log\\left[\\frac{x-\\mu}{-x+\\mu+\\sigma}\\right]\\right)^2} \\delta \\sigma}{\\sqrt{2\\pi} (x-\\mu)(-x+\\mu+\\sigma)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp(-1/2*(gamma+delta*log((x-mu)/(-x+mu+sigma)))^2)*delta*sigma/(sqrt(2*pi)*(x-mu)*(-x+mu+sigma))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001235>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale  of Power-Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale  of Power-Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "PowerNormal1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma \\in R, \\sigma > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000202>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "Poisson intensity of Zero-inflated-Poisson-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Poisson intensity of Zero-inflated-Poisson-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ZeroInflatedPoisson1.rate"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\lambda \\in R, \\lambda > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "Poisson intensity"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "rate"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000753>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Uniform Discrete 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Uniform Discrete 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{n-k}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(n-k)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001149>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degrees of freedom of Noncentral-F-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degrees of freedom of Noncentral-F-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NoncentralF1.degreesOfFreedom1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "m"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "m \\in N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degrees of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "degreesOfFreedom1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001255>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Inverse Chi-Square" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Inverse Chi-Square"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{2}{(\\nu - 2)^2(\\nu-4)} \\text{ for } \\nu>4"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000856>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 5 and Negative Binomial 1 whereby r = \\\\alpha, p = \\\\beta / 1 + \\\\beta" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000190> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000074> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "r = \\alpha, p = \\beta / (1 + \\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial5(\\alpha, \\beta) \\rightarrow NegativeBinomial1(r,p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000192>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Negative Binomial 5" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Negative Binomial 5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Sigma_{i=1}^x f(i), x \\in \\{0,1,2,...\\} \\text{ with } f \\text{ the PMF}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "cumsum(PMF)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000434>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Log-Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Log-Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(e^{\\sigma^2}\\!\\!-1) e^{2\\mu+\\sigma^2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001169>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Beta Negative Binomial1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Beta Negative Binomial1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Sigma_{i=1}^x f(i), x \\in \\{0,1,2,...\\} \\text{ with } f \\text{ the PMF}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "cumsum(PMF)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000138>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Negative Binomial 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Negative Binomial 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001293>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Johnson SB 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Johnson SB 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSB1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001294> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001295> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (\\mu,\\mu+\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001298> , <http://www.probonto.org/ontology#PROB_k0001297> , <http://www.probonto.org/ontology#PROB_k0001296> , <http://www.probonto.org/ontology#PROB_k0001299> .
+
+<http://www.probonto.org/ontology#PROB_k0000817>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label "relationship between Binomial 1 and Poisson 1 whereby \\\\lambda = np, n \\\\rightarrow \\\\infty " ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000117> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000410> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\lambda = np, n \\rightarrow \\infty "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Binomial1(n,p) \\rightarrow Poisson1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/BinomialPoisson.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000222>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "log mean of Negative-Binomial-6" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "log mean of Negative-Binomial-6"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial6.logMean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\eta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\eta \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "log mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "logMean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000016>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Multivariate Student T 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Multivariate (Student) T 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateStudentT2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000017> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in R^d, k\\geq 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000020> , <http://www.probonto.org/ontology#PROB_k0000021> , <http://www.probonto.org/ontology#PROB_k0000019> .
+
+<http://www.probonto.org/ontology#PROB_k0000799>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degrees of freedom of Multivariate-Student-T-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degrees of freedom of Multivariate-Student-T-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateStudentT1.degreesOfFreedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\nu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\nu \\ge 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degrees of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "degreesOfFreedom"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000154>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Inverse Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Inverse Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "InverseBinomial1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000155> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000157> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000158> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in  \\{0,1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000160> , <http://www.probonto.org/ontology#PROB_k0000159> .
+
+<http://www.probonto.org/ontology#PROB_k0001274>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Dagum 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Dagum 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "b{\\left( \\frac{ap-1}{a+1} \\right)}^{\\tfrac{1}{a}}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000942>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Zero-Inflated Generalized Poisson 1 and Generalized Poisson 3 whereby p0=0" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000169> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000758> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "p0=0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "ZeroInflatedGeneralizedPoisson1(\\mu,\\alpha,p0) \\rightarrow GeneralizedPoisson3(\\mu,\\alpha)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{famoye2006zero}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000417>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "Poisson intensity of Poisson-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Poisson intensity of Poisson-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Poisson1.rate"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\lambda \\in R, \\lambda > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "Poisson intensity"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "rate"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000179>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Birnbaum-Saunders 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Birnbaum-Saunders 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\int_0^x f(x),
+\\text { with f the PDF}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "cumsum(PDF*rep(stepSize,length(PDF)))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000201>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Zero-inflated Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Zero-inflated Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lambda (1-\\pi) (1 + \\lambda \\pi)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000967>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label """relationship between Hypergeometric 1 and Poisson 1 whereby X \\\\sim Hypergeometric1N, K, n \\\\Rightarrow Y\\\\sim Poisson1\\\\lambda \\\\text{ as
+K, N and n tend to infinity for } \\\\\\\\ K/N \\\\text{ small and } nK/N \\\\rightarrow \\\\lambda""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000126> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000410> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """X \\sim Hypergeometric1(N, K, n) \\Rightarrow Y\\sim Poisson1(\\lambda) \\text{ as
+K, N and n tend to infinity for } \\\\ K/N \\text{ small and } nK/N \\rightarrow \\lambda"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Hypergeometric1(N,K,n) \\rightarrow Poisson1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{forbes2011statistical}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000778>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Von Mises 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Von Mises 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000115>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "inverse scale matrix of Wishart-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "inverse scale matrix of Wishart-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Wishart2.inverseScaleMatrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "p\\times p - \\text{symmetric, positive definite matrix}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "inverse scale matrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "inverseScaleMatrix"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001343>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale parameter of Johnson-SN-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale parameter of Johnson-SN-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSN1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000814>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label """relationship between Student's t-distribution 1 and Standard Normal 1 whereby X\\\\sim StudentT1\\\\nu \\\\Rightarrow StandardNormal10,1 \\\\text{ as } \\\\nu \\\\text{ tends to infinity.}\\\\\\\\
+\\\\text{ The approximation is reasonable for } \\\\nu\\\\ge 30""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000613> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000562> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """X\\sim StudentT1(\\nu) \\Rightarrow StandardNormal1(0,1) \\text{ as } \\nu \\text{ tends to infinity.}\\\\
+\\text{ The approximation is reasonable for } \\nu\\ge 30"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StudentT1(\\nu) \\rightarrow StandardNormal1(0,1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{forbes2011statistical}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001148>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "noncentrality parameter of Noncentral-F-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "noncentrality parameter of Noncentral-F-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NoncentralF1.noncentrality"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\lambda \\geq 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "noncentrality parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "noncentrality"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000756>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Uniform Discrete 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Uniform Discrete 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{n(n+2)}{12}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001232>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Power-Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Power-Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases} \\frac{1}{K}  (\\Phi(Z) - \\Phi(-T) ) & \\text{for } \\lambda > 0 \\\\ 
+\\Phi(Z) & \\text{for } \\lambda = 0 \\\\
+\\frac{1}{K} \\Phi & \\text{for } \\lambda < 0
+\\end{cases}\\\\
+\\text{with }
+Z = \\frac{(x^\\lambda - 1) / \\lambda-\\mu}{\\sigma}
+\\quad \\text{and} \\quad 
+T = 1/(\\lambda \\sigma) + \\mu/\\sigma """^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """CDF = function(x,lambda,mu,sigma) {
+  if (lambda > 0) {
+    CDF = 1/K(lambda,mu,sigma) * ( PHI(Zfunc(x,lambda,mu,sigma)) - PHI(-Tfunc(lambda,mu,sigma)) )
+  } else if (lambda==0) {
+    CDF = PHI(Zfunc(x,lambda,mu,sigma))
+  } else if (lambda < 0) {
+    CDF = 1/K(lambda,mu,sigma) * PHI(Zfunc(x,lambda,mu,sigma))
+  }
+}
+Zfunc <- function(x,lambda,mu,sigma) { 
+  Zfunc = (BCtrafo(x,lambda)-mu) / sigma 
+  }"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001252>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Inverse Chi-Square" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Inverse Chi-Square"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Gamma\\Big(\\frac{\\nu}{2},\\frac{1}{2x}\\Big)\\Big/\\Gamma\\Big(\\frac{\\nu}{2}\\Big)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "Igamma(nu/2,1/2/x, lower=F) / gamma(nu/2) "^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000135>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Negative Binomial 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Negative Binomial 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000136> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000138> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000139> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000140> , <http://www.probonto.org/ontology#PROB_k0000141> .
+
+<http://www.probonto.org/ontology#PROB_k0000191>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Negative Binomial 5" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Negative Binomial 5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\binom {k+\\alpha-1}{\\alpha-1} \\Big(\\frac{\\beta}{\\beta + 1} \\Big)^{\\alpha} \\Big(\\frac{1}{\\beta + 1} \\Big)^{k}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "choose(k+alpha-1,alpha-1) * (beta / (beta + 1))^alpha * (1 / (beta + 1))^k"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000855>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Weibull 1 and Rayleigh 1 whereby k=2, \\\\lambda=\\\\sqrt{2} \\\\sigma" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000800> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000462> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "k=2, \\lambda=\\sqrt{2} \\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Weibull1(\\lambda,k) \\rightarrow Rayleigh1(\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000221>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Negative Binomial 6" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Negative Binomial 6"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\exp(\\eta) + \\exp(\\eta)^2 / \\phi"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000798>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "covariance matrix of Multivariate-Student-T-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "covariance matrix of Multivariate-Student-T-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateStudentT1.covarianceMatrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\Sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\Sigma, \\text{ positive-definite real } p\\times p \\text{ matrix}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "covariance matrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "covarianceMatrix"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000015>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Gompertz-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Gompertz-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Gompertz1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "b > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001273>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Dagum 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Dagum 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "b{\\left(-1+2^{\\tfrac{1}{p}}\\right)}^{-\\tfrac{1}{a}}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000437>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Poisson 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Poisson 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Poisson2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000438> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000439> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000440> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000441> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000442> .
+
+<http://www.probonto.org/ontology#PROB_k0001292>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "number of elements of Zipf-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "number of elements of Zipf-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Zipf1.numberOfElements"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "n"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "n \\in N^+"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "number of elements"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "numberOfElements"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000151>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Binomial 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Binomial 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "I_{1-logit^{-1}(\\alpha)}(n - k, 1 + k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """invLogit = function(x) { exp(x)/(1+exp(x)) } \\\\ 
+Rbeta(1-invLogit(alpha), n-k, 1+k)"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001168>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Beta Negative Binomial1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Beta Negative Binomial1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{{n-1+x \\choose x}{B(n+\\alpha,\\beta+x)}}{B(\\alpha,\\beta)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "choose(n-1+x,x)*beta(n+alpha,beta+x)/beta(alpha,beta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000777>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Von Mises 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Von Mises 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000200>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Zero-inflated Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Zero-inflated Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(1-\\pi) \\lambda"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000416>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lambda"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001147>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Noncentral F 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Noncentral F 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\left(\\frac{n}{m}\\right)^2 \\frac{2}{(n-2)(n-4)}\\left[\\frac{(\\lambda+m)^2}{n-2} +2\\lambda + m \\right]"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001271>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Dagum 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Dagum 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\left( 1+{\\left(\\frac{x}{b}\\right)}^{-a} \\right)^{-p}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(1+(x/b)^(-a))^(-p)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000968>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Student's t-distribution 1 and F 1 whereby \\\\text{If } X\\\\sim StudentT1\\\\nu \\\\Rightarrow Y=X^2 \\\\sim F1,\\\\nu" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000613> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000492> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X\\sim StudentT1(\\nu) \\Rightarrow Y=X^2 \\sim F(1,\\nu)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StudentT1(\\nu) \\rightarrow F1(n_1,n_2)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/TF.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000116>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degrees of freedom of Wishart-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degrees of freedom of Wishart-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Wishart2.degreesOfFreedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degrees of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "degreesOfFreedom"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001344>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Muth 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Muth 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Muth1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001345> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001346> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0001348> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0001347> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001349> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001350> .
+
+<http://www.probonto.org/ontology#PROB_k0000755>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Uniform Discrete 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Uniform Discrete 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{n}{2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001233>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "transforming parameter of Power-Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "transforming parameter of Power-Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "PowerNormal1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\lambda \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "transforming parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000854>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Zero-Inflated Negative Binomial 1 and Negative Binomial 2 whereby p0=0" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000142> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000105> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "p0=0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "ZeroInflatedNegativeBinomial1(\\lambda,\\tau,p0) \\rightarrow NegativeBinomial2(\\lambda,\\tau)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{Troconiz:2009fv}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000190>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Negative Binomial 5" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Negative Binomial 5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000191> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000192> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000193> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000194> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000195> , <http://www.probonto.org/ontology#PROB_k0000196> .
+
+<http://www.probonto.org/ontology#PROB_k0001253>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Inverse Chi-Square" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Inverse Chi-Square"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\nu - 2} \\text{ for } \\nu>2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000014>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Gompertz-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Gompertz-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Gompertz1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\eta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\eta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001272>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Dagum 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Dagum 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+-\\frac{b}{a}\\frac{\\Gamma\\left(-\\tfrac{1}{a}\\right)\\Gamma\\left(\\tfrac{1}{a}+p\\right)}{\\Gamma(p)} & \\text{if}\\ a>1    \\\\
+\\text{Indeterminate} & \\text{otherwise}
+\\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000940>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 1 and Log-Normal 5 whereby \\\\mu = \\\\mu, \\\\tau = 1 / \\\\sigma^2" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000428> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000526> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = \\mu, \\tau = 1 / \\sigma^2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal1(\\mu,\\sigma) \\rightarrow LogNormal5(\\mu,\\tau)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000797>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Multivariate-Student-T-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Multivariate-Student-T-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateStudentT1.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu = [\\mu_1, \\dots, \\mu_p]^T, \\mu_i \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000220>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Negative Binomial 6" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Negative Binomial 6"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\exp(\\eta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000815>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Conway-Maxwell-Poisson 1 and Poisson 1 whereby \\\\text{For } \\\\nu = 1 \\\\text{ the sum has a Poisson distribution with parameter } n\\\\lambda" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000323> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000410> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{For } \\nu = 1 \\text{ the sum has a Poisson distribution with parameter } n\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "ConwayMaxwellPoisson1(\\lambda,\\nu) \\rightarrow Poisson1(\\lambda) "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{shmueli2005useful}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000136>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Negative Binomial 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Negative Binomial 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\binom {k+\\phi-1}k \\Big(\\frac{\\phi}{\\mu + \\phi} \\Big)^{\\phi} \\Big(\\frac{\\mu}{\\mu + \\phi} \\Big)^{k}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "choose(k+phi-1,k) * (phi / (mu + phi))^phi * (mu / (mu + phi))^k"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001291>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Zipf-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Zipf-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Zipf1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha \\in R, \\alpha > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000436>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Log-Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Log-Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal1.stdevLog"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "stdevLog"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001167>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Beta Negative Binomial1" , "Beta Pascal"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Beta Negative Binomial1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "BetaNegativeBinomial1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0001168> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001169> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001170> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in \\{0,\\dots,n\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001173> , <http://www.probonto.org/ontology#PROB_k0001172> , <http://www.probonto.org/ontology#PROB_k0001171> .
+
+<http://www.probonto.org/ontology#PROB_k0000152>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "number of trials of Binomial-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "number of trials of Binomial-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Binomial2.numberOfTrials"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "n"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "n \\in N, n \\ge 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "number of trials"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "numberOfTrials"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000504>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Log-Normal 4" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Log-Normal 4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "m"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001279>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Sinh-Arcsinh 2" , "SHASH"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Sinh-Arcsinh 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "SinhArcsinh2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001280> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001281> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001285> , <http://www.probonto.org/ontology#PROB_k0001282> , <http://www.probonto.org/ontology#PROB_k0001284> , <http://www.probonto.org/ontology#PROB_k0001283> .
+
+<http://www.probonto.org/ontology#PROB_k0000246>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Normal1.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001166>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degrees of freedom of NoncentralT" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degrees of freedom of NoncentralT"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NoncentralT1.degreesOfFreedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "n"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "n \\in N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degrees of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "degreesOfFreedom"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000832>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Generalized Gamma 2 and Weibull 1 whereby c=1, a=0, b=\\\\lambda" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000644> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000800> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "c=1, a=0, b=\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "GeneralizedGamma2(a,b,c,k) \\rightarrow Weibull1(\\lambda,k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{forbes2011statistical}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000796>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Multivariate Student T 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Multivariate (Student) T 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+\\frac{\\nu}{\\nu-2} \\Sigma & \\text{for }\\nu > 2 \\\\
+undefined & \\text{else} 
+\\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000371>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Double Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Double Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """K(\\mu,\\phi) \\phi^{1/2} \\exp(-\\phi \\mu) \\frac{\\exp(-y) y^y}{y!}\\Big(\\frac{e \\mu}{y}\\Big)^{\\phi y} \\\\
+\\text{ with } \\frac{1}{K(\\mu,\\phi)} \\approx 1 + \\frac{1-\\phi}{12\\phi \\mu} \\Big( 1 + \\frac{1}{\\phi \\mu} \\Big)"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """K(mu,phi) * phi^(1/2) * exp(-phi*mu) * (exp(-y)*y^y)/factorial(y) * (exp(1)*mu/y)^(phi*y) \\\\
+# with 
+K(mu,phi) = 1 / (1 + (1-phi)/(12*mu*phi)*(1 + 1/(mu*phi)) )"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000585>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "minimum of Log-Uniform-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "minimum of Log-Uniform-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogUniform1.minimum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "min"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "min>0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "minimum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "minimum"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001250>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Inverted-chi-square"^^<en> , "Inverse Chi-Square" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Inverse Chi-Square"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "InverseChiSquare1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001251> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001252> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001253> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0001254> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001255> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001256> .
+
+<http://www.probonto.org/ontology#PROB_k0000431>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Log-Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Log-Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "e^{\\mu+\\sigma^2/2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001125>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location parameter of Asymmetric-Laplace-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location parameter of Asymmetric-Laplace-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "AsymmetricLaplace1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000919>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Binomial 2 and Binomial 1 whereby p = \\\\exp\\\\alpha / 1 + \\\\exp\\\\alpha" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000149> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000117> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "p = \\exp(\\alpha) / (1 + \\exp(\\alpha))"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Binomial2(n,\\alpha) \\rightarrow Binomial1(n,p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000399>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Erlang 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Erlang 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "b^2 c"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000207>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Burr 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Burr 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\frac{kc}{\\alpha}(x/\\alpha)^{c-1}}{1+(x/\\alpha)^c} "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(k*c)/alpha * (x/alpha)^(c-1) / (1+(x/alpha)^c)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000812>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Log-Normal 5 and Log-Normal 2 whereby \\\\mu = \\\\mu, 
+v = 1 / \\\\tau""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000526> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000453> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """\\mu = \\mu, 
+v = 1 / \\tau"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal5(\\mu,\\tau) \\rightarrow LogNormal2(\\mu,v)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000485>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median / geometric mean of Log-Normal-3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median / geometric mean of Log-Normal-3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal3.median"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "m"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "m>0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "median / geometric mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "median"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001450>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Amoroso 1 and Chi-squared 1 whereby \\\\text{ChiSquared1}k \\\\text{ distribution is a special case of the Amoroso1} a,\\\\theta,\\\\alpha,\\\\beta \\\\text{ distribution when } a = 0, \\\\theta=2, \\\\alpha=k/2, \\\\beta=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001082> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000299> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{ChiSquared1}(k) \\text{ distribution is a special case of the Amoroso1} (a,\\theta,\\alpha,\\beta) \\text{ distribution when } a = 0, \\theta=2, \\alpha=k/2, \\beta=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Amoroso1(a,\\theta,\\alpha,\\beta) \\rightarrow ChiSquared1(k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{crooks2010amoroso}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001078>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Log-Logistic 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Log-Logistic 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{1+(\\lambda x)^\\kappa}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(1+(lambda*x)^kappa)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000306>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degrees of freedom of Chi-squared-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degrees of freedom of Chi-squared-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ChiSquared1.degreesOfFreedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "k \\in N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degrees of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "degreesOfFreedom"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000833>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 5 and Negative Binomial 2 whereby \\\\lambda = \\\\alpha / \\\\beta, \\\\tau = 1 / \\\\alpha" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000190> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000105> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\lambda = \\alpha / \\beta, \\tau = 1 / \\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial5(\\alpha, \\beta) \\rightarrow NegativeBinomial2(\\lambda, \\tau)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001278>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale parameter of Dagum-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale parameter of Dagum-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Dagum1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "b > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000247>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "standard deviation of Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "standard deviation of Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Normal1.stdev"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma> 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "standard deviation"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "stdev"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000150>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Binomial 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Binomial 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "{n \\choose k}\\, \\big(logit^{-1}(\\alpha)\\big)^k \\big(1-logit^{-1}(\\alpha)\\big)^{n-k}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """invLogit = function(x) { exp(x)/(1+exp(x)) } 
+choose(n,k)*invLogit(alpha)^k*(1-invLogit(alpha))^(n-k)"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000503>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Log-Normal 4" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Log-Normal 4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "m \\sqrt{cv^2 + 1}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001165>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "noncentrality parameter of NoncentralT" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "noncentrality parameter of NoncentralT"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NoncentralT1.noncentrality"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\lambda \\geq 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "noncentrality parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "noncentrality"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000586>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "maximum of Log-Uniform-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "maximum of Log-Uniform-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogUniform1.maximum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "max"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "max \\geq min"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "maximum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "maximum"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000795>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Multivariate Student T 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Multivariate (Student) T 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000372>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Double Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Double Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Sigma_{i=1}^x f(i), x \\in \\{0,1,2,...\\} \\text{ with } f \\text{ the PMF}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "cumsum(PMF)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001251>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Inverse Chi-Square" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Inverse Chi-Square"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{2^{-\\nu/2}}{\\Gamma(\\nu/2)} x^{-(\\nu/2+1)} \\exp\\Big(-\\frac{1}{2x}\\Big) "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "2^(-nu/2)/gamma(nu/2)*x^(-(nu/2+1))*exp(-1/(2*x))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000430>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Log-Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Log-Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac12 + \\frac12\\,\\text{erf}\\Big[\\frac{\\log x-\\mu}{\\sqrt{2}\\sigma}\\Big]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/2 + 1/2 *erf( (log(x)-mu)/(sqrt(2)*sigma) )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000206>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Burr 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Burr 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1 - \\frac{1}{\\Big[1+(x/\\alpha)^c\\Big]^k}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1 - 1/(1+(x/alpha)^c)^k"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000813>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Generalized Poisson 1 and Poisson 1 whereby \\\\delta = 0, \\\\theta=\\\\mu" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000712> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000410> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\delta = 0, \\theta=\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "GeneralizedPoisson1(\\theta,\\delta) \\rightarrow Poisson1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{Yang:2007vn}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000305>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Chi-squared 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Chi-squared 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "2k"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001126>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale parameter of Asymmetric-Laplace-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale parameter of Asymmetric-Laplace-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "AsymmetricLaplace1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma \\geq 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001079>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1 - \\frac{\\Gamma(\\beta,x/\\alpha)}{\\Gamma(\\beta)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001050>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "Level start of Trapezoidal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Level start of Trapezoidal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Trapezoidal1.levelStart"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "a \\leq b < c"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "Level start"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "levelStart"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001451>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Power-Normal 1 and Truncated Normal 1 whereby PowerNormal1 \\\\text{ converges to } TruncatedNormal1 \\\\text{ when } \\\\lambda \\\\rightarrow 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001230> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000681> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "PowerNormal1 \\text{ converges to } TruncatedNormal1 \\text{ when } \\lambda \\rightarrow 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "PowerNormal1(\\lambda,\\mu,\\sigma) \\rightarrow TruncatedNormal1(\\mu,\\sigma,a,b)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{LavielleBook:2014}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000484>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Log-Normal 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Log-Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "m^2 e^{\\sigma^2} [e^{\\sigma^2}-1]"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001164>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of NoncentralT" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of NoncentralT"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "sqrt(n/2)*gamma((n-1)/2) / gamma(n/2)*delta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000058>
+      a       owl:DatatypeProperty ;
+      rdfs:label "parameter has mathematical type" .
+
+<http://www.probonto.org/ontology#PROB_k0000830>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Log-Normal 3 and Log-Normal 5 whereby \\\\mu = \\\\logm, 
+\\\\tau = 1 / \\\\sigma^2""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000478> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000526> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """\\mu = \\log(m), 
+\\tau = 1 / \\sigma^2"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal3(m,\\sigma) \\rightarrow LogNormal5(\\mu,\\tau)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000433>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Log-Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Log-Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "e^{\\mu-\\sigma^2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001277>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Dagum-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Dagum-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Dagum1.shape2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "a > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000506>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Log-Normal 4" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Log-Normal 4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "m^2 (cv^2+1) cv^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001052>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "Upper bound of Trapezoidal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Upper bound of Trapezoidal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Trapezoidal1.upperBound"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "d"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "c \\leq d"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "Upper bound"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "upperBound"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000244>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000583>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Log-Uniform 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Log-Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{max-min}{\\log(max) - \\log(min)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000794>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Multivariate Student T 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Multivariate (Student) T 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000397>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Erlang 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Erlang 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "bc"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000205>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Burr 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Burr 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\frac{kc}{\\alpha}(x/\\alpha)^{c-1}}{\\Big[1+(x/\\alpha)^c\\Big]^{k+1}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "k*c/alpha * (x/alpha)^(c-1) / (1+(x/alpha)^c)^(k+1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001123>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Asymmetric Laplace 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Asymmetric Laplace 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000288>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Laplace-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Laplace-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Laplace2.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000810>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Weibull-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Weibull-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Weibull1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "k\\in (0, +\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000119>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "I_{1-p}(n - k, 1 + k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "Rbeta(1-p, n-k, 1+k)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001051>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "Level end of Trapezoidal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Level end of Trapezoidal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Trapezoidal1.levelEnd"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "c"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "b < c \\leq d"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "Level end"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "levelEnd"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000308>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{e^{-\\frac{x-\\mu}{s}}} {s\\left(1+e^{-\\frac{x-\\mu}{s}}\\right)^2}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp(-(x-mu)/s) / (s*(1+exp(-(x-mu)/s))^2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000078>
+      a       owl:Class ;
+      rdfs:label "Limiting" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000063> .
+
+<http://www.probonto.org/ontology#PROB_k0000483>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Log-Normal 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Log-Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "m/e^{\\sigma^2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001452>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Amoroso 1 and Chi 1 whereby \\\\text{Chi1}k \\\\text{ distribution is a special case of the Amoroso1} a,\\\\theta,\\\\alpha,\\\\beta \\\\text{ distribution when } a = 0, \\\\theta=\\\\sqrt{2}, \\\\alpha=k/2, \\\\beta=2" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001082> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001243> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{Chi1}(k) \\text{ distribution is a special case of the Amoroso1} (a,\\theta,\\alpha,\\beta) \\text{ distribution when } a = 0, \\theta=\\sqrt{2}, \\alpha=k/2, \\beta=2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Amoroso1(a,\\theta,\\alpha,\\beta) \\rightarrow Chi1(k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{crooks2010amoroso}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000570>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "standard deviation of Standard-Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "standard deviation of Standard-Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StandardNormal1.stdev"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "standard deviation"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "stdev"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001163>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of NoncentralT" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of NoncentralT"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{e^{-\\frac{\\delta^2}{2}}}{\\sqrt{n\\pi} \\;\\Gamma\\left(\\frac{n}2\\right)} \\sum^{\\infty}_{r=0} \\frac{(t' \\delta)^r}{r! n^{\\frac{r}2}} \\left(1+\\frac{t'^2}{n}\\right)^{-\\frac{n+r+1}{2}}2^{\\frac{r}{2}} \\, \\Gamma\\left(\\frac{n+r+1}{2}\\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """exp(-delta^2/2)/(sqrt(n*pi) * gamma(n/2)) * PDFsum(x,delta,n,lowerLimit,upperLimit)
+PDFsum = function(x,delta,n,fromValue,toValue) {
+  PDF=array(0,length(x));
+  for(j in 1:length(x)) {
+    for(r in fromValue:toValue) {
+      PDF[j] = PDF[j] + (x[j]*delta)^r / (factorial(r)*n^(r/2)) * (1+x[j]^2/n)^(-(n+r+1)/2) * 2^(r/2) *gamma((n+r+1)/2)
+    }
+  }
+  return(PDF)
+}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000831>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Weibull 1 and Weibull 2 whereby v=k, \\\\lambda = 1/\\\\lambda^k" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000800> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000022> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "v=k, \\lambda = 1/\\lambda^k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Weibull1(\\lambda,k) \\rightarrow Weibull2(\\lambda,v)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000505>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Log-Normal 4" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Log-Normal 4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "m/(cv^2+1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001276>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Dagum-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Dagum-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Dagum1.shape1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "p > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000432>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Log-Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Log-Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "e^{\\mu}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000245>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sigma^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000793>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Multivariate Student T 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Multivariate (Student) T 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+\\mu & \\text{for }\\nu > 1 \\\\
+undefined & \\text{else} 
+\\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000370>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Double Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Double Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "DoublePoisson1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000371> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000372> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000373> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000374> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in \\{1,2,3,\\dots,n\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000376> , <http://www.probonto.org/ontology#PROB_k0000375> .
+
+<http://www.probonto.org/ontology#PROB_k0000584>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Log-Uniform 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Log-Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\frac{max^2-min^2}{2[\\log(max) - \\log(min)]} -
+\\Big(\\frac{max-min}{\\log(max) - \\log(min)}\\Big)^2"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000398>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Erlang 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Erlang 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "b(c-1), c \\ge 1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000204>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Singh-Maddala"^^<en> , "Burr 1" , "Burr Type XII"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Burr 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Burr1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000205> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000206> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0000208> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0000207> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000210> , <http://www.probonto.org/ontology#PROB_k0000211> , <http://www.probonto.org/ontology#PROB_k0000209> .
+
+<http://www.probonto.org/ontology#PROB_k0001124>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Asymmetric Laplace 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Asymmetric Laplace 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu^2 + 2\\sigma^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000307>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Logistic1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000308> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000309> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000310> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000311> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000312> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000313> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000314> , <http://www.probonto.org/ontology#PROB_k0000315> .
+
+<http://www.probonto.org/ontology#PROB_c0000079>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has alternate name" .
+
+<http://www.probonto.org/ontology#PROB_k0000289>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "precision of Laplace-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "precision of Laplace-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Laplace2.tau"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\tau"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\tau > 0, \\tau \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "precision"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "tau"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000059>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has Latex expression of support" .
+
+<http://www.probonto.org/ontology#PROB_k0000482>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Log-Normal 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Log-Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "m"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000811>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Binomial 1 and Bernoulli 1 whereby n=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000117> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000000> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "n=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Binomial1(n,p) \\rightarrow Bernoulli1(p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/BinomialBernoulli.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001101>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Arcsine 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Arcsine 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000792>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Multivariate Student T 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Multivariate (Student) T 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\text{no analytic expression}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000621>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Generalized Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Generalized Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedGamma1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000622> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000623> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000624> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000625> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000626> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000628> , <http://www.probonto.org/ontology#PROB_k0000627> , <http://www.probonto.org/ontology#PROB_k0000629> .
+
+<http://www.probonto.org/ontology#PROB_k0000375>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "Poisson intensity of Double-Poisson-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Poisson intensity of Double-Poisson-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "DoublePoisson1.rate"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R, \\mu > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "Poisson intensity"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "rate"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000836>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Log-Normal 5 and Log-Normal 3 whereby m = \\\\exp\\\\mu, 
+\\\\sigma = 1 / \\\\sqrt{\\\\tau}""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000526> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000478> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """m = \\exp(\\mu), 
+\\sigma = 1 / \\sqrt{\\tau}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal5(\\mu,\\tau) \\rightarrow LogNormal3(m,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000461>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Log-Normal-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Log-Normal-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal2.varLog"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "v"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "v > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "varLog"^^<en> .
+
+<http://www.probonto.org/ontology>
+      a       owl:Ontology .
+
+<http://www.probonto.org/ontology#PROB_k0001073>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 7 and Log-Normal 6 whereby m = \\\\mu_N/\\\\sqrt{1+\\\\sigma_N^2/\\\\mu_N^2}, \\\\sigma_g = \\\\exp\\\\Big\\\\sqrt{\\\\log1+\\\\sigma_N^2/\\\\mu_N^2}\\\\Big" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001028> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000553> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "m = \\mu_N/\\sqrt{1+\\sigma_N^2/\\mu_N^2}, \\sigma_g = \\exp\\Big(\\sqrt{\\log(1+\\sigma_N^2/\\mu_N^2)}\\Big)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal7(\\mu_N,\\sigma_N) \\rightarrow LogNormal6(m,\\sigma_g)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000589>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Standard Uniform 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Standard Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "x"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000056>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has variate of mathematical type" .
+
+<http://www.probonto.org/ontology#PROB_k0001162>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "NoncentralT" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "NoncentralT"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NoncentralT1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001163> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001164> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "t'=\\frac{x}{\\sqrt{y/n}} \\text{ with } x \\sim Normal2(\\delta,1), y \\sim ChiSquared1(n)."^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "t' \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001166> , <http://www.probonto.org/ontology#PROB_k0001165> .
+
+<http://www.probonto.org/ontology#PROB_k0000173>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Zero-Inflated Generalized Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Zero-Inflated Generalized Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(1-p0)[\\mu^2 + \\mu(1 + \\alpha \\mu)^2] - (1-p0)^2 \\mu^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000481>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Log-Normal 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Log-Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "m e^{\\frac{1}{2}\\sigma^2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001161>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Two-Sided-Power-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Two-Sided-Power-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "TwoSidedPower1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "n"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "n > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000528>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Log-Normal 5" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Log-Normal 5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac12 + \\frac12\\,\\text{erf}\\Big[\\frac{\\log x-\\mu}{\\sqrt{2/\\tau}}\\Big]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/2 + 1/2 * erf( (log(x)-mu) / sqrt(2/tau) )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000302>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Chi-squared 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Chi-squared 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "k"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001074>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Bernoulli 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Bernoulli 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+    0 & \\text{for }k<0 \\\\ q & \\text{for }0\\leq k<1 \\\\ 1 & \\text{for }k\\geq 1
+    \\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000508>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "coefficient of variation of Log-Normal-4" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "coefficient of variation of Log-Normal-4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal4.coefVar"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "cv"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "cv>0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "coefficient of variation"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "coefVar"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001142>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Benford 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Benford 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\approx 6.0565"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000949>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Standard Uniform 1 and Frechet 2 whereby \\\\text{If } X \\\\sim StandardUniform10,1 \\\\text{ then } m+\\\\sigma-\\\\logX^{-1/\\\\alpha} \\\\sim Frechet2\\\\alpha, \\\\sigma, m" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000587> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000543> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X \\sim StandardUniform1(0,1) \\text{ then } m+\\sigma(-\\log(X))^{-1/\\alpha} \\sim Frechet2(\\alpha, \\sigma, m)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StandardUniform1(0,1) \\rightarrow Frechet2(\\alpha,\\sigma,m)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/Fr%C3%A9chet_distribution} "^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000286>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Laplace 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Laplace 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000395>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Erlang 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Erlang 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{(x/b)^{c-1}}{b(c-1)! \\sum^{c-1}_{i=0} \\frac{(x/b)^i}{i!}}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000772>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "lower triangular matrix of Multivariate-Normal-3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "lower triangular matrix of Multivariate-Normal-3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateNormal3.choleskyFactor"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "L"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "L \\in R^{K \\times K}, \\text{ lower triangular and such that } LL^T \\text{ is positive definite}, \\text{with } K \\in N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "lower triangular matrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "choleskyFactor"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001121>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Asymmetric Laplace 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Asymmetric Laplace 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\frac{1}{\\sigma}\\frac{\\kappa}{1+\\kappa^2}
+\\begin{cases}
+\\exp ( \\frac{1}{\\sigma\\kappa}x )  & \\text{if }x < 0 \\\\
+\\exp \\left( -\\frac{\\kappa}{\\sigma}x \\right) & \\text{if }x \\geq 0 
+\\end{cases}\\\\
+\\text{with }
+\\kappa = \\frac{2\\sigma}{\\sqrt{4\\sigma^2+\\mu^2}+\\mu}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """kappa = function(mu,sigma){ 2*sigma/(sqrt(4*sigma^2+mu^2)+mu) }
+PDF1 = function(x,mu,sigma) { 
+  1/sigma*kappa(mu,sigma)/(1+kappa(mu,sigma)^2)*exp(1/(sigma*kappa(mu,sigma))*x ) }
+PDF2 = function(x,mu,sigma) { 
+  1/sigma*kappa(mu,sigma)/(1+kappa(mu,sigma)^2)*exp( -kappa(mu,sigma)/sigma *x) }"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001102>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Arcsine 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Arcsine 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000376>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "dispersion of Double-Poisson-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "dispersion of Double-Poisson-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "DoublePoisson1.dispersion"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\phi"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\phi \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "dispersion"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "dispersion"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000620>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degrees of freedom of Student-s-t-distribution-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degrees of freedom of Student-s-t-distribution-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StudentT1.degreesOfFreedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\nu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\nu > 0, \\nu \\in  R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degrees of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "degreesOfFreedom"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000791>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Multivariate Student T 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Multivariate (Student) T 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\Gamma\\left[(\\nu+p)/2\\right]}{\\Gamma(\\nu/2)\\nu^{p/2}\\pi^{p/2}\\left|\\Sigma\\right|^{1/2}\\left[1+\\frac{1}{\\nu}(x-\\mu)^{\\rm T}\\Sigma^{-1}(x-\\mu)\\right]^{(\\nu+p)/2}}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000460>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of logx of Log-Normal-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of log(x) of Log-Normal-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal2.meanLog"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean of log(x)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "meanLog"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000057>
+      a       owl:DatatypeProperty ;
+      rdfs:label "parameter has mathematical type" .
+
+<http://www.probonto.org/ontology#PROB_k0000174>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Zero-Inflated-Generalized-Poisson-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Zero-Inflated-Generalized-Poisson-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ZeroInflatedGeneralizedPoisson1.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001075>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Half-normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Half-normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "erf\\Big(\\frac{x-\\mu}{\\sqrt{2}\\sigma}\\Big)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "erf((x-mu) / (sqrt(2)*sigma))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000301>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Chi-squared 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Chi-squared 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\Gamma\\left(\\frac{k}{2}\\right)}\\; \\gamma\\left(\\frac{k}{2},\\,\\frac{x}{2}\\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/gamma(k/2) * Igamma(k/2,x/2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000527>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Log-Normal 5" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Log-Normal 5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sqrt{\\frac{\\tau}{2 \\pi}} \\frac{1}{x}e^{-\\frac{\\tau}{2}(\\log x-\\mu)^2}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "sqrt(tau / (2*pi)) * (1/x) * exp(- (tau/2)*(log(x)-mu)^2 )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000480>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Log-Normal 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Log-Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac12 + \\frac12\\,\\text{erf}\\Big[\\frac{\\log x-\\log m}{\\sqrt{2}\\sigma}\\Big]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/2 + 1/2 * erf( (log(x)-log(m)) / (sqrt(2)*sigma) )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001160>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Two-Sided-Power-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Two-Sided-Power-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "TwoSidedPower1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "m"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "a < m < b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000287>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Laplace 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Laplace 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "2 / \\tau^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000837>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Weibull 2 and Weibull 1 whereby k=v, \\\\lambda = \\\\lambda^{-1/v}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000022> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000800> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "k=v, \\lambda = \\lambda^{-1/v}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Weibull2(\\lambda,v) \\rightarrow Weibull1(\\lambda,k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001141>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Benford 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Benford 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000507>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median / geometric mean of Log-Normal-4" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median / geometric mean of Log-Normal-4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal4.median"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "m"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "m>0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "median / geometric mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "median"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001122>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Asymmetric Laplace 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Asymmetric Laplace 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+\\frac{\\kappa^2}{1+\\kappa^2} \\exp \\left( \\frac{1}{\\sigma\\kappa}x \\right)  & \\text{if }x \\leq 0\\\\
+1 -\\frac{1}{1+\\kappa^2} \\exp \\left( -\\frac{\\kappa}{\\sigma}x \\right) & \\text{if }x >0 
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """kappa = function(mu,sigma){ 2*sigma/(sqrt(4*sigma^2+mu^2)+mu) }
+CDF1 = function(x,mu,sigma) { 
+  kappa(mu,sigma)^2/(1+kappa(mu,sigma)^2)*exp(1/(sigma*kappa(mu,sigma))*x )}
+CDF2 = function(x,mu,sigma) { 
+  1-1/(1+kappa(mu,sigma)^2)*exp(-kappa(mu,sigma)/sigma*x)}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000771>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Multivariate-Normal-3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Multivariate-Normal-3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateNormal3.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R^K"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000396>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Erlang 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Erlang 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Big[\\exp\\Big(-\\frac{x}{b}\\Big)\\Big]\\Big( \\sum^{c-1}_{i=0} \\frac{(x/b)^i}{i!}\\Big)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000790>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Multivariate Student T 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Multivariate (Student) T 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateStudentT1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000791> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000792> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000793> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000794> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000795> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000796> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in R^p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000798> , <http://www.probonto.org/ontology#PROB_k0000797> , <http://www.probonto.org/ontology#PROB_k0000799> .
+
+<http://www.probonto.org/ontology#PROB_k0000229>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Categorical Ordered 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Categorical Ordered 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "i\\text{ such that }p_i=\\max(p_1, \\ldots, p_k)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000623>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Generalized Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Generalized Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\gamma(d/p, (x/a)^p)}{\\Gamma(d/p)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "Igamma(d/p, (x/a)^p, lower=T) / gamma(d/p)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000373>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Double Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Double Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000587>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Standard Uniform 1" , "Rectangular"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Standard Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StandardUniform1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000588> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000589> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0000591> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000592> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000593> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000594> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [0,1]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000595> , <http://www.probonto.org/ontology#PROB_k0000596> .
+
+<http://www.probonto.org/ontology#PROB_k0000170>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Zero-Inflated Generalized Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Zero-Inflated Generalized Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+p0 + (1-p0) \\exp\\Big[ \\frac{-\\mu}{1+\\alpha \\mu}\\Big] & \\text{for } y = 0 \\\\ 
+(1-p0) \\Big( \\frac{\\mu}{1+\\alpha \\mu}\\Big)^y \\frac{(1+\\alpha y)^{y-1}}{y!} \\exp\\Big[ \\frac{-\\mu (1+\\alpha y)}{1+\\alpha \\mu}\\Big] & \\text{for } y > 0
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """PMF1=p0 + (1-p0) * exp(-mu/(1+ alpha*mu)) # for y = 0
+PMF2=(1-p0)*( mu/(1+alpha*mu))^y*((1+alpha*y)^(y-1))/factorial(y)*exp((-mu*(1+alpha*y))/(1+alpha*mu)) # for y > 0"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000054>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has variate symbol in Latex" .
+
+<http://www.probonto.org/ontology#PROB_k0000248>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Categorical Nonordered 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Categorical Nonordered 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "CategoricalNonordered1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000249> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000250> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000251> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000252> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000253> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000254> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in \\{1,\\dots,k\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000255> .
+
+<http://www.probonto.org/ontology#PROB_k0000834>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Rice 1 and Rayleigh 1 whereby \\\\text{If } R \\\\sim Rice10,\\\\sigma \\\\text{ then } R \\\\sim Rayleigh1\\\\sigma" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000487> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000462> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } R \\sim Rice1(0,\\sigma) \\text{ then } R \\sim Rayleigh1(\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Rice1(\\nu,\\sigma) \\rightarrow Rayleigh1(\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/Rice_distribution}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000947>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Zero-Inflated Generalized Poisson 1 and Poisson 1 whereby p0=0, \\\\alpha=0, \\\\lambda=\\\\mu" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000169> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000410> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "p0=0, \\alpha=0, \\lambda=\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "ZeroInflatedGeneralizedPoisson1(\\mu,\\alpha,p0) \\rightarrow Poisson1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001140>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Benford 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Benford 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "3"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000304>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Chi-squared 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Chi-squared 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "max\\{k-2,0\\}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000284>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Laplace 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Laplace 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\tau}{2} \\exp \\left(-\\tau|x-\\mu| \\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "tau/2 * exp(-tau * abs(x-mu))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001076>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Weibull 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Weibull 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\exp(-x^v \\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp(-x^v * lambda)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000268>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000209>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale parameter of Burr-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale parameter of Burr-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Burr1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000988>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Half-normal-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Half-normal-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "HalfNormal2.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma> 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000393>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Erlang 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Erlang 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{(x/b)^{c-1} \\exp(-x/b)}{b(c-1)!}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "((x/b)^(c-1) *exp(-x/b)) / (b * factorial(c-1))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001181>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Weibull-Discrete-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Weibull-Discrete-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "WeibullDiscrete1.shape1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "0<p<1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000770>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Multivariate Normal 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Multivariate Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "LL^T"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000374>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Double Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Double Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu/\\phi"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000228>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Categorical Ordered 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Categorical Ordered 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "i\\text{ such that }\\sum_{j=1}^{i-1} p_j \\leq 0.5\\text{ and }\\sum_{j=1}^{i} p_j \\geq 0.5"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000622>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Generalized Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Generalized Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{p/a^d}{\\Gamma(d/p)} x^{d-1}e^{-(x/a)^p}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "p/a^d/gamma(d/p) * x^(d-1) * exp(-(x/a)^p)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001100>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Arcsine 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Arcsine 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\pi -2 \\arcsin\\left(2x -1\\right)}{2\\pi}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(pi - 2 * asin(2*x -1)) / (2*pi)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000055>
+      a       owl:ObjectProperty ;
+      rdfs:label "has variate of mathematical type" .
+
+<http://www.probonto.org/ontology#PROB_k0000171>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Zero-Inflated Generalized Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Zero-Inflated Generalized Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Sigma_{i=1}^x f(i), x \\in \\{0,1,2,...\\} \\text{ with } f \\text{ the PMF}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "c(PMF1,cumsum(PMF2)+PMF1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000529>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Log-Normal 5" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Log-Normal 5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "e^{\\mu + \\frac{1}{2\\tau}}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000588>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Standard Uniform 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Standard Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000249>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Categorical Nonordered 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Categorical Nonordered 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "p(x=i)=p_i"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000835>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Log-Normal 1 and Normal 1 whereby \\\\logX" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000428> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\log(X)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal1(\\mu,\\sigma) \\rightarrow Normal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/NormalLognormal.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000509>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Scaled Inverse Chi-Square" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Scaled Inverse Chi-Square"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ScaledInverseChiSquare1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000510> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000511> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000512> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000513> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000514> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000515> , <http://www.probonto.org/ontology#PROB_k0000516> .
+
+<http://www.probonto.org/ontology#PROB_k0000948>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Exponential 2 and F 1 whereby \\\\text{If } X_1, X_2 \\\\sim Exponential21 \\\\text{ mutually independent and identically distributed} \\\\\\\\ \\\\text{ random variables } \\\\Rightarrow X_1/X_2 \\\\text{ has the } F1 \\\\text{ distribution}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000443> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000492> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X_1, X_2 \\sim Exponential2(1) \\text{ mutually independent and identically distributed} \\\\ \\text{ random variables } \\Rightarrow X_1/X_2 \\text{ has the } F1 \\text{ distribution}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Exponential2(1) \\rightarrow F1(n_1,n_2)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/ExponentialF.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000269>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001077>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Log-Logistic 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Log-Logistic 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\lambda \\kappa (\\lambda x)^{\\kappa-1}}{1+(\\lambda x)^\\kappa}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "lambda * kappa * (lambda * x)^(kappa-1) / (1+(lambda * x)^kappa)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000172>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Zero-Inflated Generalized Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Zero-Inflated Generalized Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(1-p0)\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000285>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Laplace 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Laplace 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+\\frac12 \\exp \\left( \\tau (x-\\mu) \\right) & \\mbox{if }x < \\mu \\\\
+1-\\frac12 \\exp \\left( -\\tau (x-\\mu) \\right) & \\mbox{if }x \\geq \\mu
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """1/2 * exp( tau*(x-mu) ) # for x < mu
+1- 1/2 * exp( -tau*(x-mu) ) # x >= mu"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000303>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Chi-squared 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Chi-squared 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\approx k\\bigg(1-\\frac{2}{9k}\\bigg)^3"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000208>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Burr 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Burr 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\Big[1+(x/\\alpha)^c\\Big]^k}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(1+(x/alpha)^c)^k"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001120>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Asymmetric Laplace 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Asymmetric Laplace 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "AsymmetricLaplace1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001121> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001122> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001123> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001124> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001125> , <http://www.probonto.org/ontology#PROB_k0001126> .
+
+<http://www.probonto.org/ontology#PROB_k0000199>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Zero-inflated Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Zero-inflated Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Sigma_{i=1}^x f(i), x \\in \\{0,1,2,...\\} \\text{ with } f \\text{ the PMF}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "c(PMF1,cumsum(PMF2)+PMF1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001180>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Weibull Discrete 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Weibull Discrete 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(1-p)^{x^\\beta}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(1-p)^(x^beta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000987>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Half-normal-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Half-normal-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "HalfNormal2.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000394>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Erlang 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Erlang 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1 - \\Big[\\exp\\Big(-\\frac{x}{b}\\Big)\\Big]\\Big( \\sum^{c-1}_{i=0} \\frac{(x/b)^i}{i!}\\Big)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "R function"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001447>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Beta 1 and Arcsine 1 whereby \\\\alpha=1/2, \\\\beta = 1/2" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000057> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001096> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\alpha=1/2, \\beta = 1/2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Beta1(\\alpha,\\beta) \\rightarrow Arcsine1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.math.wm.edu/~leemis/chart/UDR/UDR.html}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000327>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Conway-Maxwell-Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Conway-Maxwell-Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\text{No closed form}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000985>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Half-normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Half-normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu + \\sigma \\sqrt{\\frac{2}{\\pi}}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000011>
+      a       owl:Class ;
+      rdfs:label "non denumerable set" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000006> .
+
+<http://www.probonto.org/ontology#PROB_k0001182>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Weibull-Discrete-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Weibull-Discrete-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "WeibullDiscrete1.shape2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000604>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Lomax 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Lomax 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Lomax1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000605> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000606> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000607> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000608> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000609> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000610> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000612> , <http://www.probonto.org/ontology#PROB_k0000611> .
+
+<http://www.probonto.org/ontology#PROB_k0001426>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Two-Sided Power 1 and Uniform 1 whereby n=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001151> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000703> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "n=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "TwoSidedPower1(a,b,m,n) \\rightarrow Uniform1(a,b)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/TSPUniform.pdf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000523>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Frechet 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Frechet 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+   \\ \\sigma^2\\left(\\Gamma\\left(1-\\frac{2}{\\alpha}\\right)- \\left(\\Gamma\\left(1-\\frac{1}{\\alpha}\\right)\\right)^2\\right)  & \\text{for } \\alpha>2  \\\\
+    \\ \\infty              & \\text{otherwise}
+\\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000073>
+      a       owl:DatatypeProperty ;
+      rdfs:label "distribution relationship definition in Latex" .
+
+<http://www.probonto.org/ontology#PROB_k0000279>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "x_0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000452>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Exponential-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Exponential-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Exponential2.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000710>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "minimum of Uniform-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "minimum of Uniform-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Uniform1.minimum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "a \\in  R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "minimum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "minimum"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001070>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Pareto Type I and Exponential 1 whereby X \\\\sim ParetoTypeI1,Y= \\\\logX/\\\\lambda \\\\Rightarrow Y \\\\sim  Exponential1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000361> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000418> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "X \\sim ParetoTypeI1,Y= \\log(X/\\lambda) \\Rightarrow Y \\sim  Exponential1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "ParetoTypeI1(x_m,\\alpha) \\rightarrow Exponential1(\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/ParetoExponential.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001397>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Levy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Levy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "c/2(\\textrm{erfc}^{-1}(1/2))^2 \\text{ for } \\mu=0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000053>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has variate symbol" .
+
+<http://www.probonto.org/ontology#PROB_k0000368>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Pareto-Type-I" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Pareto-Type-I"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ParetoTypeI1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "x_m"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "x_m > 0, x_m \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000564>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Standard Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Standard Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac12\\left[1 + \\text{erf}\\left( \\frac{x}{\\sqrt{2}}\\right)\\right]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/2 * (1 + erf(x/(sqrt(2))))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001406>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Amoroso 1 and Rayleigh 1 whereby \\\\text{Rayleigh1}\\\\sigma \\\\text{ distribution is a special case of the Amoroso1} a,\\\\theta,\\\\alpha,\\\\beta \\\\text{ distribution when } a = 0, \\\\theta=\\\\sqrt{2\\\\sigma^2}, \\\\alpha=1, \\\\beta=2" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001082> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000462> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{Rayleigh1}(\\sigma) \\text{ distribution is a special case of the Amoroso1} (a,\\theta,\\alpha,\\beta) \\text{ distribution when } a = 0, \\theta=\\sqrt{2\\sigma^2}, \\alpha=1, \\beta=2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Amoroso1(a,\\theta,\\alpha,\\beta) \\rightarrow Rayleigh1(\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{crooks2010amoroso}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000677>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Multivariate Gaussian Process Distribution 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Multivariate Gaussian Process Distribution 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\prod^K_{i=1} \\text{MultivariateNormal1}(x_i|0,w^{-1}_i \\Sigma)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000904>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Bernoulli 2 and Bernoulli 1 whereby p = \\\\exp\\\\alpha / 1 + \\\\exp\\\\alpha" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000028> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000000> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "p = \\exp(\\alpha) / (1 + \\exp(\\alpha))"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Bernoulli2(\\alpha) \\rightarrow Bernoulli1(p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000624>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Generalized Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Generalized Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "a \\frac{\\Gamma((d+1)/p)}{\\Gamma(d/p)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001033>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Log-Normal 7" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Log-Normal 7"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\mu_N}{(1+\\sigma_N^2/\\mu_N^2)^{3/2}}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000251>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Categorical Nonordered 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Categorical Nonordered 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "E([x=i]) = p_i, \\text{this is the mean of the Iverson bracket } [x=i] \\text{ and not the mean of } x"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000031>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has Latex symbol" .
+
+<http://www.probonto.org/ontology#PROB_k0000924>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Pareto Type II and Lomax 1 whereby \\\\mu=0" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000386> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000604> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu=0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "ParetoTypeII1(\\mu,\\lambda,\\alpha) \\rightarrow Lomax1(\\lambda,\\alpha)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/Pareto_distribution#Pareto_types_I.E2.80.93IV}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001446>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label "relationship between Amoroso 1 and Normal 1 whereby \\\\text{Normal1}\\\\mu,\\\\sigma \\\\text{ distribution is a special case of the Amoroso1} a,\\\\theta,\\\\alpha,\\\\beta \\\\text{ distribution when } a=\\\\mu-\\\\sigma\\\\sqrt{\\\\alpha}, \\\\theta=\\\\sigma/\\\\sqrt{\\\\alpha}, \\\\beta=1 \\\\text{ and } \\\\alpha \\\\rightarrow \\\\infty" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001082> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{Normal1}(\\mu,\\sigma) \\text{ distribution is a special case of the Amoroso1} (a,\\theta,\\alpha,\\beta) \\text{ distribution when } a=\\mu-\\sigma\\sqrt{\\alpha}, \\theta=\\sigma/\\sqrt{\\alpha}, \\beta=1 \\text{ and } \\alpha \\rightarrow \\infty"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Amoroso1(a,\\theta,\\alpha,\\beta) \\rightarrow Normal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{crooks2010amoroso}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000986>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Half-normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Half-normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sigma^2 (1-\\frac{2}{\\pi})"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000328>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Conway-Maxwell-Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Conway-Maxwell-Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sum_{j=0}^\\infty \\frac{j^2\\lambda^j}{(j!)^\\nu Z(\\lambda, \\nu)} - \\text{Mean}^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000278>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "x_0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000072>
+      a       owl:ObjectProperty ;
+      rdfs:label "distribution relationship to" .
+
+<http://www.probonto.org/ontology#PROB_k0000605>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Lomax 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Lomax 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              " {\\alpha \\over \\lambda} \\left[{1+ {x \\over \\lambda}}\\right]^{-(\\alpha+1)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "alpha/lambda* (1+ x/lambda)^(-(alpha+1))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001183>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Borel 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Borel 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Borel1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0001184> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001185> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{1,2,\\dots,\\infty\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001186> .
+
+<http://www.probonto.org/ontology#PROB_c0000010>
+      a       owl:Class ;
+      rdfs:label "denumerable set" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000006> .
+
+<http://www.probonto.org/ontology#PROB_k0000524>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Frechet-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Frechet-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Frechet1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha \\in R^+"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001427>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Two-Sided Power 1 and Triangular 1 whereby n=2" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001151> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000661> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "n=2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "TwoSidedPower1(a,b,m,n) \\rightarrow Triangular1(a,b,m)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/TSPTriangular.pdf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000453>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Log-Normal 2" , "lognormal"^^<en> , "Galton"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Log-Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000454> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000455> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000456> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000457> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000458> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000459> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000460> , <http://www.probonto.org/ontology#PROB_k0000461> .
+
+<http://www.probonto.org/ontology#PROB_c0000052>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has type name" .
+
+<http://www.probonto.org/ontology#PROB_k0000367>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Pareto Type I" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Pareto Type I"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+     \\infty & \\text{for }\\alpha\\in(1,2] \\\\
+     \\frac{x_m^2\\alpha}{(\\alpha-1)^2(\\alpha-2)} & \\text{for }\\alpha>2
+   \\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000563>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Standard Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Standard Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{e^{-\\frac{1}{2} x^2}}{\\sqrt{2\\pi}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(sqrt(2*pi))*exp(-x^2/2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001407>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Sinh-Arcsinh 2 and Normal 1 whereby \\\\epsilon=0,\\\\delta=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001279> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\epsilon=0,\\delta=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "SinhArcsinh2(\\mu,\\sigma,\\epsilon,\\delta) \\rightarrow  Normal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{rubio2013modelling}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001398>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Levy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Levy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{c}{3}  \\text{ for } \\mu=0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001184>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Borel 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Borel 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{e^{\\mu n} (\\mu n)^{n-1}}{n!}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "e^(mu*n)*(mu*n)^(n-1) / factorial(n)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000676>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Multivariate Gaussian Process Distribution 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Multivariate Gaussian Process Distribution 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateGaussianProcess1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000677> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in R^{K\\times N}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000680> , <http://www.probonto.org/ontology#PROB_k0000679> .
+
+<http://www.probonto.org/ontology#PROB_k0000903>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Truncated Normal 1 and Half-normal 1 whereby \\\\mu=0, a=0, b=\\\\infty" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000681> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000068> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu=0, a=0, b=\\infty"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "TruncatedNormal1(\\mu,\\sigma,a,b) \\rightarrow HalfNormal1(\\theta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\url{http://reference.wolfram.com/language/ref/HalfNormalDistribution.html} \\\\
+\\cite{forbes2011statistical}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000030>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has comment" .
+
+<http://www.probonto.org/ontology#PROB_k0000923>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 3 and Negative Binomial 1 whereby r=\\\\phi, p=r/\\\\mu+r" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000135> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000074> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "r=\\phi, p=r/(\\mu+r)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial3(\\mu, \\phi) \\rightarrow NegativeBinomial1(r, p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000250>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Categorical Nonordered 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Categorical Nonordered 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "undefined"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000625>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Generalized Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Generalized Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "a \\left(\\frac{d-1}{p}\\right)^{\\frac{1}{p}}, \\text{ for } d>1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001032>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Log-Normal 7" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Log-Normal 7"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\mu_N}{\\sqrt{1+\\sigma_N^2/\\mu_N^2}}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000325>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Conway-Maxwell-Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Conway-Maxwell-Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Sigma_{i=1}^x f(i), x \\in \\{0,1,2,...\\} \\text{ with } f \\text{ the PMF}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "cumsum(PMF)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000478>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Log-Normal 3" , "lognormal"^^<en> , "Galton"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Log-Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000479> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000480> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000481> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000482> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000483> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000484> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000485> , <http://www.probonto.org/ontology#PROB_k0000486> .
+
+<http://www.probonto.org/ontology#PROB_k0001449>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Arcsine 2 and Arcsine 1 whereby a=0, b=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001105> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001096> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "a=0, b=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Arcsine2(a,b) \\rightarrow Arcsine1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000071>
+      a       owl:ObjectProperty ;
+      rdfs:label "distribution relationship from" .
+
+<http://www.probonto.org/ontology#PROB_c0000013>
+      a       owl:Class ;
+      rdfs:label "enumeration" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000006> .
+
+<http://www.probonto.org/ontology#PROB_k0000983>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Half-normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Half-normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sqrt{\\frac{2}{\\pi}} \\frac{1}{\\sigma} \\exp\\Big[-\\frac{1}{2}\\Big(\\frac{x-\\mu}{\\sigma}\\Big)^2\\Big]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "sqrt(2/pi)*1/sigma * exp(-1/2 * ((x-mu)/sigma)^2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000926>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Log-Normal 2 and Log-Normal 6 whereby m=\\\\exp\\\\mu, 
+\\\\sigma_g=\\\\exp\\\\sqrt{v}""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000453> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000553> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """m=\\exp(\\mu), 
+\\sigma_g=\\exp(\\sqrt{v})"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal2(\\mu,v) \\rightarrow LogNormal6(m,\\sigma_g)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000277>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "undefined"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000525>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Frechet-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Frechet-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Frechet1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma \\in R^+"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001428>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Standard Two-Sided Power 1 and Standard Uniform 1 whereby n=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001379> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000587> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "n=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StandardTwoSidedPower1(m,n) \\rightarrow StandardUniform1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001408>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Amoroso 1 and Inverse Chi-Square whereby \\\\text{InverseChiSquare1}k \\\\text{ distribution is a special case of the Amoroso1} a,\\\\theta,\\\\alpha,\\\\beta \\\\text{ distribution when } a = 0, \\\\theta=1/2, \\\\alpha=k/2, \\\\beta=-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001082> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001250> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{InverseChiSquare1}(k) \\text{ distribution is a special case of the Amoroso1} (a,\\theta,\\alpha,\\beta) \\text{ distribution when } a = 0, \\theta=1/2, \\alpha=k/2, \\beta=-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Amoroso1(a,\\theta,\\alpha,\\beta) \\rightarrow InverseChiSquare1(k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{crooks2010amoroso}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001399>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Levy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Levy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\infty"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000712>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Generalized Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Generalized Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedPoisson1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000713> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000714> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000715> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000716> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              """k
+"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000718> , <http://www.probonto.org/ontology#PROB_k0000717> .
+
+<http://www.probonto.org/ontology#PROB_c0000051>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has short name" .
+
+<http://www.probonto.org/ontology#PROB_k0000450>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Exponential 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Exponential 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001072>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 6 and Log-Normal 7 whereby \\\\mu_N = m \\\\exp\\\\big\\\\frac12 \\\\log^2\\\\sigma_g\\\\big, \\\\sigma_N = m \\\\exp\\\\big\\\\frac12 \\\\log^2\\\\sigma_g\\\\big \\\\sqrt{\\\\exp\\\\big[\\\\log^2\\\\sigma_g\\\\big]-1 }" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000553> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001028> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu_N = m \\exp\\big(\\frac12 \\log^2(\\sigma_g)\\big), \\sigma_N = m \\exp\\big(\\frac12 \\log^2(\\sigma_g)\\big) \\sqrt{\\exp\\big[\\log^2(\\sigma_g)\\big]-1 }"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal6(m,\\sigma_g) \\rightarrow LogNormal7(\\mu_N,\\sigma_N)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001031>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Log-Normal 7" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Log-Normal 7"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu_N"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000679>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "symmetric, positive definite kernel matrix of Multivariate-Gaussian-Process-Distribution-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "symmetric, positive definite kernel matrix of Multivariate-Gaussian-Process-Distribution-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateGaussianProcess1.kernelMatrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\Sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\Sigma \\in R^{N \\times N}, N \\in N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "symmetric, positive definite kernel matrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "kernelMatrix"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000626>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Generalized Gamma 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Generalized Gamma 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "a^2\\left(\\frac{\\Gamma((d+2)/p)}{\\Gamma(d/p)} - \\left(\\frac{\\Gamma((d+1)/p)}{\\Gamma(d/p)}\\right)^2\\right)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000650>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Generalized-Gamma-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Generalized-Gamma-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedGamma2.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "a > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000566>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Standard Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Standard Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000366>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Pareto Type I" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Pareto Type I"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "x_m"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000606>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Lomax 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Lomax 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1- \\left[{1+ {x \\over \\lambda}}\\right]^{-\\alpha}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1- (1+ x/lambda)^(-alpha)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001372>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Standard Triangular 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Standard Triangular 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}\\frac12 x^2+x+\\frac12 & \\text{ for } -1 < x < 0\\\\
+-\\frac12 x^2+x+\\frac12 & \\text{ for } 0 \\leq x < 1\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """CDF1=1/2*x^2+x+1/2 
+CDF2=-1/2*x^2+x+1/2"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000906>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Standard Uniform 1 and Uniform 1 whereby X \\\\sim StandardNormal1 \\\\text{ and } Y = a + b-a X \\\\Rightarrow Y \\\\sim Uniform1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000587> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000703> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "X \\sim StandardNormal1 \\text{ and } Y = a + (b-a) X \\Rightarrow Y \\sim Uniform1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StandardUniform1(0,1) \\rightarrow Uniform1(a,b)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/StandarduniformUniform.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001185>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Borel 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Borel 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Sigma_{i=1}^x f(i), x \\in \\{1,2,...\\} \\text{ with } f \\text{ the PMF}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "cumsum(PMF)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000033>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has MathML symbol" .
+
+<http://www.probonto.org/ontology#PROB_k0001370>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Standard Triangular 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Standard Triangular 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StandardTriangular1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001371> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001372> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0001374> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0001373> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001375> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0001376> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0001377> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001378> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "0 \\leq x \\leq 1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000479>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Log-Normal 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Log-Normal 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{x\\sigma\\sqrt{2\\pi}}\\ e^{-\\frac{\\left[\\log (x/m)\\right]^2}{2\\sigma^2}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(x*sigma*sqrt(2*pi)) * exp(-(log(x/m))^2 / (2*sigma^2))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000326>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Conway-Maxwell-Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Conway-Maxwell-Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sum_{j=0}^\\infty \\frac{j\\lambda^j}{(j!)^\\nu Z(\\lambda, \\nu)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000276>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\pi} \\arctan\\left(\\frac{x-x_0}{\\gamma}\\right)+\\frac{1}{2}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/pi * atan((x-x0)/gamma)+1/2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000070>
+      a       owl:Class ;
+      rdfs:label "Model formulation" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000063> .
+
+<http://www.probonto.org/ontology#PROB_c0000012>
+      a       owl:Class ;
+      rdfs:label "infinite set" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000006> .
+
+<http://www.probonto.org/ontology#PROB_k0001448>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Amoroso 1 and Half-normal 2 whereby \\\\text{HalfNormal2}\\\\mu,\\\\sigma \\\\text{ distribution is a special case of the Amoroso1} a,\\\\theta,\\\\alpha,\\\\beta \\\\text{ distribution for } \\\\mu=0 \\\\text{ and when } a = 0, \\\\theta=\\\\sqrt{2\\\\sigma^2}, \\\\alpha=1/2, \\\\beta=2" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001082> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000982> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{HalfNormal2}(\\mu,\\sigma) \\text{ distribution is a special case of the Amoroso1} (a,\\theta,\\alpha,\\beta) \\text{ distribution for } \\mu=0 \\text{ and when } a = 0, \\theta=\\sqrt{2\\sigma^2}, \\alpha=1/2, \\beta=2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Amoroso1(a,\\theta,\\alpha,\\beta) \\rightarrow HalfNormal2(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{crooks2010amoroso}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000925>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 3 and Log-Normal 1 whereby \\\\mu = \\\\logm, \\\\sigma = \\\\sigma" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000478> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000428> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = \\log(m), \\sigma = \\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal3(m,\\sigma) \\rightarrow LogNormal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001119>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Noncentral-Beta-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Noncentral-Beta-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NoncentralBeta1.shape2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000526>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "lognormal"^^<en> , "Log-Normal 5" , "Galton"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Log-Normal 5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal5"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000527> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000528> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000529> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000530> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000531> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000532> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000533> , <http://www.probonto.org/ontology#PROB_k0000534> .
+
+<http://www.probonto.org/ontology#PROB_k0001429>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Normal 1 and Levy 1 whereby Y\\\\,\\\\sim\\\\,\\\\textrm{Normal}\\\\mu,\\\\sigma \\\\Rightarrow {Y-\\\\mu}^{-2} \\\\sim\\\\,\\\\textrm{Levy}0,1/\\\\sigma" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001393> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "Y\\,\\sim\\,\\textrm{Normal}(\\mu,\\sigma) \\Rightarrow {(Y-\\mu)}^{-2} \\sim\\,\\textrm{Levy}(0,1/\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Normal1(\\mu,\\sigma) \\rightarrow Levy1(\\mu,c)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/L%C3%A9vy_distribution#Related_distributions}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001409>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Sinh-Arcsinh 2 and Standard Normal 1 whereby \\\\mu=0, \\\\sigma=1, \\\\epsilon=0,\\\\delta=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001279> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000562> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu=0, \\sigma=1, \\epsilon=0,\\delta=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "SinhArcsinh2(\\mu,\\sigma,\\epsilon,\\delta) \\rightarrow StandardNormal1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{rubio2013modelling}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001071>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 7 and Log-Normal 5 whereby m = \\\\log \\\\Big\\\\mu_N/\\\\sqrt{1+\\\\sigma_N^2/\\\\mu_N^2}\\\\Big, \\\\tau = 1/\\\\log\\\\big1+\\\\sigma_N^2/\\\\mu_N^2\\\\big" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001028> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000526> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "m = \\log \\Big(\\mu_N/\\sqrt{1+\\sigma_N^2/\\mu_N^2}\\Big), \\tau = 1/\\log\\big(1+\\sigma_N^2/\\mu_N^2\\big)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal7(\\mu_N,\\sigma_N) \\rightarrow LogNormal5(\\mu,\\tau)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000451>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Exponential 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Exponential 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\beta^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000711>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "maximum of Uniform-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "maximum of Uniform-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Uniform1.maximum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "b \\in R, a < b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "maximum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "maximum"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000627>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Generalized-Gamma-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Generalized-Gamma-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedGamma1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "a > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000032>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has plain text symbol" .
+
+<http://www.probonto.org/ontology#PROB_k0000651>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Generalized-Gamma-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Generalized-Gamma-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedGamma2.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "b > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000905>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Standard Uniform 1 and Beta 1 whereby aX_1, X_2,... , X_n iid \\\\sim StandardNormal1 \\\\Rightarrow \\\\text{ with } \\\\alpha=r \\\\text{ and } \\\\beta=n-r+1, X_{r} \\\\sim Beta\\\\alpha,\\\\beta" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000587> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000057> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "aX_1, X_2,... , X_n (iid) \\sim StandardNormal1 \\Rightarrow \\text{ with } \\alpha=r \\text{ and } \\beta=n-r+1, X_{(r)} \\sim Beta(\\alpha,\\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StandardUniform1(0,1) \\rightarrow Beta1(alpha,beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/StandarduniformBeta.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000050>
+      a       owl:DatatypeProperty ;
+      rdfs:label "parameter has definition expressed in MathML" .
+
+<http://www.probonto.org/ontology#PROB_k0001186>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "rate of Borel-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "rate of Borel-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Borel1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in (0,1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "rate"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001371>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Standard Triangular 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Standard Triangular 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+x+1 & \\text{ for } -1 < x < 0 \\\\
+1-x & \\text{ for } 0 \\leq x < 1
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """x+1 for -1 < x < 0 \\\\
+1-x for 0 <= x < 1 """^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000565>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Standard Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Standard Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000607>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Lomax 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Lomax 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\lambda}{\\alpha -1} \\text{ for } \\alpha > 1 \\text { otherwise undefined }"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000365>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Pareto Type I" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Pareto Type I"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "x_m \\sqrt[\\alpha]{2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001118>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Noncentral-Beta-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Noncentral-Beta-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NoncentralBeta1.shape1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000077>
+      a       owl:Class ;
+      rdfs:label "Special case, Reparameterisation" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000063> .
+
+<http://www.probonto.org/ontology#PROB_k0000476>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "standard deviation of Exponentially-modified-Gaussian-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "standard deviation of Exponentially-modified-Gaussian-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ExponentiallyModifiedGaussian1.stdev"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma> 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "standard deviation"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "stdev"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001443>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Scaled Inverse Chi-Square and Inverse Chi-Square whereby \\\\mbox{If } X \\\\sim \\\\mbox{Scale-inv-}\\\\chi^2\\\\nu, \\\\tau^2 \\\\mbox{ then } \\\\frac{X}{\\\\tau^2 \\\\nu} \\\\sim \\\\mbox{inv-}\\\\chi^2\\\\nu" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000509> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001250> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mbox{If } X \\sim \\mbox{Scale-inv-}\\chi^2(\\nu, \\tau^2) \\mbox{ then } \\frac{X}{\\tau^2 \\nu} \\sim \\mbox{inv-}\\chi^2(\\nu)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "ScaledInverseChiSquare1 \\rightarrow InverseChiSquare1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/Scaled_inverse_chi-squared_distribution}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000540>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Skew-Normal" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Skew-Normal"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "SkewNormal1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000069>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Half-normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Half-normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{2\\theta}{\\pi} e^{-\\theta^2 x^2 / \\pi}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "2*theta/pi * exp(-theta^2 * x^2 / pi)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000628>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Generalized-Gamma-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Generalized-Gamma-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedGamma1.shape1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "d"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "d > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000040>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Gumbel-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Gumbel-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Gumbel1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta>0, \\beta \\in  R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000928>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Normal 1 and Chi-squared 1 whereby \\\\text{If } X_i \\\\sim N\\\\mu,\\\\sigma, i=1,2,...,n \\\\text{ are mutually independent and identically}\\\\\\\\\\\\text{ distributed random variables and } Y=\\\\sum_{i=1}^n X_i - \\\\mu/\\\\sigma^2 \\\\Rightarrow Y \\\\sim ChiSquared1n" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000299> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X_i \\sim N(\\mu,\\sigma), i=1,2,...,n \\text{ are mutually independent and identically}\\\\\\text{ distributed random variables and } Y=\\sum_{i=1}^n ((X_i - \\mu)/\\sigma)^2 \\Rightarrow Y \\sim ChiSquared1(n)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Normal1(\\mu,\\sigma) \\rightarrow ChiSquared1(n)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/NormalChisquare.pdf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000275>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\pi\\gamma\\,\\left[1 + \\left(\\frac{x-x_0}{\\gamma}\\right)^2\\right]}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1 / (pi*gamma*(1 + ((x-x0)^2/gamma^2)))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000600>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Gamma 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Gamma 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "r / \\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000900>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Bernoulli 1 and Bernoulli 2 whereby \\\\alpha = \\\\logp/1-p" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000000> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000028> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\alpha = \\log(p/(1-p))"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Bernoulli1(p) \\rightarrow Bernoulli2(\\alpha)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000035>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has plain text expression" .
+
+<http://www.probonto.org/ontology#PROB_k0001187>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Half Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Half Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "HalfCauchy1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001188> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001189> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0001190> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001191> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0001192> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001193> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000255>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "category probabilities of Categorical-Nonordered-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "category probabilities of Categorical-Nonordered-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "CategoricalNonordered1.categoryProb"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "p_1, \\ldots, p_k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "0 \\leq p_i \\leq 1, \\Sigma p_i = 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "category probabilities"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "categoryProb"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000456>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Log-Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Log-Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "e^{\\mu+v/2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000594>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Standard Uniform 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Standard Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\text{any value in }[0,1]"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001318>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Johnson-SL-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Johnson-SL-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSL1.shape2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\delta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\delta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001402>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "LKJ Correlation 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "LKJ Correlation 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LKJCorrelation1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001403> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "\\Sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "\\text{positive-definite, symmetric matrix with unit diagonal (i.e., a correlation matrix)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001404> .
+
+<http://www.probonto.org/ontology#PROB_k0000560>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median / geometric mean of Log-Normal-6" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median / geometric mean of Log-Normal-6"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal6.median"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "m"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "m>0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "median / geometric mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "median"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000714>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Generalized Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Generalized Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Sigma_{i=1}^x f(i), x \\in \\{0,1,2,...\\} \\text{ with } f \\text{ the PMF}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "cumsum(PMF)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000309>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{1+e^{-\\frac{x-\\mu}{s}}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(1+exp(-(x-mu)/s))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001117>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "noncentrality parameter of Noncentral-Beta-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "noncentrality parameter of Noncentral-Beta-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NoncentralBeta1.noncentrality"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\lambda \\geq 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "noncentrality parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "noncentrality"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000982>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Half-normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Half-normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "HalfNormal2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000983> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001075> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000985> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000986> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [\\mu,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000988> , <http://www.probonto.org/ontology#PROB_k0000987> .
+
+<http://www.probonto.org/ontology#PROB_k0001442>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Amoroso 1 and Gamma 1 whereby \\\\text{Gamma1 distribution is a special case of the Amoroso1} a,\\\\theta,\\\\alpha,\\\\beta \\\\text{ distribution when} a = 0, \\\\beta=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001082> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000571> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{Gamma1 distribution is a special case of the Amoroso1} (a,\\theta,\\alpha,\\beta) \\text{ distribution when} a = 0, \\beta=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Amoroso1(a,\\theta,\\alpha,\\beta) \\rightarrow Gamma1(k,\\theta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{crooks2010amoroso}
+"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000068>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Half-normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Half-normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "HalfNormal1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000069> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000070> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000071> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000072> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000073> .
+
+<http://www.probonto.org/ontology#PROB_c0000076>
+      a       owl:Class ;
+      rdfs:label "Reparameterisation, Limiting" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000063> .
+
+<http://www.probonto.org/ontology#PROB_k0000927>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 3 and Negative Binomial 2 whereby \\\\lambda=\\\\mu, \\\\tau=1/\\\\phi" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000135> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000105> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\lambda=\\mu, \\tau=1/\\phi"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial3(\\mu, \\phi) \\rightarrow NegativeBinomial2(\\lambda, \\tau)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000601>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Gamma 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Gamma 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "r / \\mu^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000041>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Nakagami 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Nakagami 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Nakagami1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000042> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000043> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000044> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000045> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000046> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000047> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000049> , <http://www.probonto.org/ontology#PROB_k0000048> .
+
+<http://www.probonto.org/ontology#PROB_k0000629>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Generalized-Gamma-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Generalized-Gamma-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedGamma1.shape2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "p > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000520>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Frechet 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Frechet 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+   \\ \\sigma\\Gamma\\left(1-\\frac{1}{\\alpha}\\right)  & \\text{for } \\alpha>1  \\\\
+   \\ \\infty              & \\text{otherwise}
+\\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000477>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "rate or inverse scale of Exponentially-modified-Gaussian-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "rate or inverse scale of Exponentially-modified-Gaussian-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ExponentiallyModifiedGaussian1.rate"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\lambda > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "rate or inverse scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "rate"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000274>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Breit-Wigner"^^<en> , "Cauchy 1" , "Lorentz"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Cauchy1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000275> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000276> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000277> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000278> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000279> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000280> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000281> , <http://www.probonto.org/ontology#PROB_k0000282> .
+
+<http://www.probonto.org/ontology#PROB_k0000254>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Categorical Nonordered 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Categorical Nonordered 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "Var([x=i]) = p_i (1-p_i); \\quad Cov([x=i],[x=j]) = - p_i p_j~~(i\\neq j)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000034>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has Latex expression" .
+
+<http://www.probonto.org/ontology#PROB_k0000593>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Standard Uniform 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Standard Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0.5"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000457>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Log-Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Log-Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "e^{\\mu}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001188>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Half Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Half Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac2\\pi \\frac1{1+x^2}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "2/pi * 1 / (1 + x^2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001317>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Johnson-SL-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Johnson-SL-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSL1.shape1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\gamma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\gamma \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000500>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "lognormal"^^<en> , "Log-Normal 4" , "Galton"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Log-Normal 4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000501> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000502> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000503> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000504> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000505> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000506> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000508> , <http://www.probonto.org/ontology#PROB_k0000507> .
+
+<http://www.probonto.org/ontology#PROB_k0001403>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of LKJ Correlation 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of LKJ Correlation 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\propto \\det(\\Sigma)^{(\\eta-1)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000713>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Generalized Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Generalized Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\theta (\\theta+\\delta k)^{k-1}\\times e^{-\\theta - \\delta k}}{k!}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(theta*(theta+k*delta)^(k-1) * exp(-theta-k*delta)) / factorial(k)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000067>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Beta-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Beta-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Beta1.beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "beta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000075>
+      a       owl:DatatypeProperty ;
+      rdfs:label "distribution relationship reference" .
+
+<http://www.probonto.org/ontology#PROB_k0000542>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Skew-Normal" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Skew-Normal"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "SkewNormal1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000521>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Frechet 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Frechet 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\sigma}{\\sqrt[\\alpha]{\\log_e(2)}}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000474>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Exponentially modified Gaussian 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Exponentially modified Gaussian 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sigma^2 + 1/\\lambda^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001116>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Noncentral Beta 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Noncentral Beta 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sum_{j = 0}^{\\infty} e^{-\\lambda/2} \\frac{\\left(\\frac{\\lambda}{2}\\right)^j}{j!} I_x \\left(\\alpha + j,\\beta\\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """CDFsum = function(x,alpha,beta,lambda,fromValue,toValue) { 
+  CDF=array(0,length(x));
+  for(j in 1:length(x)) {
+    for(k in fromValue:toValue) {
+      CDF[j] = CDF[j] + exp(-lambda/2) * (lambda/2)^k / factorial(k) * Rbeta(x[j],alpha+k,beta,lower=T)
+    }
+  }
+  return(CDF)
+}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000716>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Generalized Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Generalized Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\theta}{(1 -\\delta)^3}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000273>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Normal-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Normal-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Normal2.var"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "v"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "v>0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "variance"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "var"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000602>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Gamma-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Gamma-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Gamma2.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "r"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "r > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000902>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Generalized Gamma 2 and Generalized Gamma 1 whereby a = 0, kc=d, \\\\text{ and rename } k=p, b=a" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000644> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000621> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "a = 0, kc=d, \\text{ and rename } k=p, b=a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "GeneralizedGamma2(a,b,c,k) \\rightarrow GeneralizedGamma1(a,d,p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000037>
+      a       owl:ObjectProperty ;
+      rdfs:label "distribution has PDF" .
+
+<http://www.probonto.org/ontology#PROB_k0000329>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "Poisson intensity of Conway-Maxwell-Poisson-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Poisson intensity of Conway-Maxwell-Poisson-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ConwayMaxwellPoisson1.rate"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\lambda \\in R, \\lambda > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "Poisson intensity"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "rate"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001445>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Chi 1 and Chi-squared 1 whereby \\\\text{If }X \\\\sim Chi1k \\\\text{ then } X^2 \\\\sim ChiSquared1k" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001243> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000299> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If }X \\sim Chi1(k) \\text{ then } X^2 \\sim ChiSquared1(k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Chi1(k) \\rightarrow ChiSquared1(k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/Chi_distribution}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001189>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Half Cauchy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Half Cauchy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac2\\pi \\arctan(x)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "2/pi * atan(x)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000349>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Dirichlet 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Dirichlet 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "x_i = \\frac{\\alpha_i - 1}{\\sum_{i=1}^K\\alpha_i - K}, \\quad \\alpha_i > 1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000592>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Standard Uniform 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Standard Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0.5"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000253>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Categorical Nonordered 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Categorical Nonordered 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "i\\text{ such that }p_i=\\max(p_1, \\ldots, p_k)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000562>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Standard Normal 1" , "Standard Gaussian"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Standard Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StandardNormal1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000563> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000564> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0001336> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0001335> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000565> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000566> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000567> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000568> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000569> , <http://www.probonto.org/ontology#PROB_k0000570> .
+
+<http://www.probonto.org/ontology#PROB_k0001404>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape  of LKJ-Correlation-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape  of LKJ-Correlation-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LKJCorrelation1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\eta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\eta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000501>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Log-Normal 4" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Log-Normal 4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{x\\sqrt{\\log(cv^2+1)}\\sqrt{2\\pi}}\\ e^{-\\frac{\\left[\\log (x/m)\\right]^2}{2\\ln(cv^2+1)}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(x*sqrt(log(cv^2+1))*sqrt(2*pi)) * exp( -(log(x/m))^2 / (2*log(cv^2+1)) )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000454>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Log-Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Log-Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{x\\sqrt{v}\\sqrt{2\\pi}}\\ e^{-\\frac{\\left(\\log x-\\mu\\right)^2}{2 v}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/(x*sqrt(v)*sqrt(2*pi)) * exp(-(ln(x)-mu)^2/(2*v))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000074>
+      a       owl:DatatypeProperty ;
+      rdfs:label "distribution relationship pair expression Latex" .
+
+<http://www.probonto.org/ontology#PROB_k0000389>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Pareto-Type-II" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Pareto-Type-II"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ParetoTypeII1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000541>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Skew-Normal" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Skew-Normal"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "SkewNormal1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma> 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001444>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Amoroso 1 and Levy 1 whereby \\\\text{Levy1}\\\\mu,c \\\\text{ distribution is a special case of the Amoroso1} a,\\\\theta,\\\\alpha,\\\\beta \\\\text{ distribution when } \\\\theta=c/2, \\\\alpha=1/2, \\\\beta=-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001082> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001393> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{Levy1}(\\mu,c) \\text{ distribution is a special case of the Amoroso1} (a,\\theta,\\alpha,\\beta) \\text{ distribution when } \\theta=c/2, \\alpha=1/2, \\beta=-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Amoroso1(a,\\theta,\\alpha,\\beta) \\rightarrow Levy1(\\mu,c)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{crooks2010amoroso}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000066>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Beta-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Beta-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Beta1.alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "alpha"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001115>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Noncentral Beta 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Noncentral Beta 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sum_{j = 0}^{\\infty} e^{-\\lambda/2} \\frac{\\left(\\frac{\\lambda}{2}\\right)^j}{j!}\\frac{x^{\\alpha + j - 1}\\left(1-x\\right)^{\\beta - 1}}{\\mathrm{B}\\left(\\alpha + j,\\beta\\right)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """PDFsum = function(x,alpha,beta,lambda,fromValue,toValue) {
+  PDF=array(0,length(x));
+  for(i in 1:length(x)) {
+    for(j in fromValue:toValue) {
+      PDF[i] = PDF[i] + exp(-lambda/2) * (lambda/2)^j / factorial(j) * (x[i]^(alpha+j-1)*(1-x[i])^(beta-1)) / beta(alpha+j,beta)
+    }
+  }
+  return(PDF)
+}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000475>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Exponentially-modified-Gaussian-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Exponentially-modified-Gaussian-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ExponentiallyModifiedGaussian1.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000522>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Frechet 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Frechet 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sigma\\left(\\frac{\\alpha}{1+\\alpha}\\right)^{1/\\alpha}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000901>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label "relationship between Beta 1 and Normal 1 whereby \\\\alpha = \\\\beta, \\\\beta \\\\rightarrow \\\\infty" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000057> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\alpha = \\beta, \\beta \\rightarrow \\infty"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Beta1(alpha,beta) \\rightarrow Normal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/BetaNormal.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000272>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Normal-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Normal-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Normal2.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000603>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "rate of Gamma-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "rate of Gamma-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Gamma2.rate"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "rate"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "rate"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000929>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Frechet 1 and Weibull 1 whereby X \\\\sim Frechet1\\\\alpha,\\\\sigma \\\\rightarrow X^{-1} \\\\sim Weibull\\\\lambda=1/\\\\sigma,k=\\\\alpha" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000517> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000800> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "X \\sim Frechet1(\\alpha,\\sigma) \\rightarrow X^{-1} \\sim Weibull(\\lambda=1/\\sigma,k=\\alpha)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Frechet1(\\alpha,\\sigma) \\rightarrow Weibull1(\\lambda,k)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\url{https://en.wikipedia.org/wiki/Fr%C3%A9chet_distribution} \\\\
+\\cite{stan-manual:2015b}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001319>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location parameter of Johnson-SL-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location parameter of Johnson-SL-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSL1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000252>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Categorical Nonordered 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Categorical Nonordered 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "i\\text{ such that }\\sum_{j=1}^{i-1} p_j \\leq 0.5\\text{ and }\\sum_{j=1}^{i} p_j \\geq 0.5"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000455>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Log-Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Log-Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac12 + \\frac12\\,\\text{erf}\\Big[\\frac{\\log x-\\mu}{\\sqrt{2}\\sqrt{var}}\\Big]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/2 + 1/2 * erf( (log(x)-mu) / (sqrt(2)*sqrt(var)) )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000591>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Standard Uniform 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Standard Uniform 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1-x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1-x"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000061>
+      a       owl:DatatypeProperty ;
+      rdfs:label "has MathML expression" .
+
+<http://www.probonto.org/ontology#PROB_k0001405>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Cauchy 1 and Standard Cauchy 1 whereby x0=0, \\\\gamma=1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000274> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001300> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "x0=0, \\gamma=1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Cauchy1(x_0,\\gamma) \\rightarrow StandardCauchy1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{https://en.wikipedia.org/wiki/Cauchy_distribution}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000561>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Log-Normal-6" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Log-Normal-6"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal6.geomStdev"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma_g"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma_g > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "geomStdev"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000369>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Pareto-Type-I" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Pareto-Type-I"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ParetoTypeI1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha > 0, \\alpha \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000715>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Generalized Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Generalized Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\theta}{1 -\\delta}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000502>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Log-Normal 4" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Log-Normal 4"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac12 + \\frac12\\,\\text{erf}\\Big[\\frac{\\log x-\\log m}{\\sqrt{2}\\sqrt{\\log(cv^2+1)}}\\Big]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/2 + 1/2 * erf( (log(x)-log(m)) / (sqrt(2*log(cv^2+1))) )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000085>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Wishart 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Wishart 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "n V"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000230>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Categorical Ordered 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Categorical Ordered 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "Var([x=i]) = p_i (1-p_i); \\quad Cov([x=i],[x=j]) = - p_i p_j~~(i\\neq j)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000146>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Zero-Inflated-Negative-Binomial-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Zero-Inflated-Negative-Binomial-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ZeroInflatedNegativeBinomial1.rate"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\lambda > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "rate"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000852>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Bernoulli 1 and Binomial 1 whereby \\\\Sigma X iid" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000000> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000117> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\Sigma X (iid)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Bernoulli1(p) \\rightarrow Binomial1(n,p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/BernoulliBinomial.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000019>
+      a       owl:Class ;
+      rdfs:label "random variable" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000005> .
+
+<http://www.probonto.org/ontology#PROB_k0001314>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Johnson SL 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Johnson SL 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSL1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001315> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001316> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001319> , <http://www.probonto.org/ontology#PROB_k0001318> , <http://www.probonto.org/ontology#PROB_k0001320> , <http://www.probonto.org/ontology#PROB_k0001317> .
+
+<http://www.probonto.org/ontology#PROB_k0000270>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001378>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Standard Triangular 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Standard Triangular 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "42375"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000024>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Weibull 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Weibull 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1- \\exp(-x^v \\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1- exp(-x^v * lambda)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000737>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of GeneralizedPoisson2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of GeneralizedPoisson2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Sigma_{i=1}^x f(i), x \\in \\{0,1,2,...\\} \\text{ with } f \\text{ the PMF}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "cumsum(PMF)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000008>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Gompertz 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Gompertz 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Gompertz1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000009> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000010> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0000012> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0000011> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000013> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000014> , <http://www.probonto.org/ontology#PROB_k0000015> .
+
+<http://www.probonto.org/ontology#PROB_k0000697>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape2 of Generalized-Negative-Binomial-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape2 of Generalized-Negative-Binomial-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedNegativeBinomial1.m"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "m"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "m > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "m"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001350>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape parameter of Muth-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape parameter of Muth-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Muth1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\kappa"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "0 \\leq \\kappa \\leq 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000544>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Frechet 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Frechet 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\alpha}{\\sigma} \\Big(\\frac{x-m}{\\sigma}\\Big)^{-\\alpha-1} \\exp\\Big(-\\Big(\\frac{x-m}{\\sigma}\\Big)^{-\\alpha}\\Big)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "alpha/sigma * ((x-m)/sigma)^(-alpha-1) * exp(-((x-m)/sigma)^(-alpha))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000271>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "v"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000757>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "number of values of Uniform-Discrete-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "number of values of Uniform-Discrete-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "UniformDiscrete2.numberOfValues"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "n"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "n \\in N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "number of values"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "numberOfValues"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000039>
+      a       owl:ObjectProperty ;
+      rdfs:label "distribution has CDF" .
+
+<http://www.probonto.org/ontology#PROB_k0000044>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Nakagami 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Nakagami 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\Gamma(m+\\frac{1}{2})}{\\Gamma(m)} \\Big(\\frac{\\Omega}{m}\\Big)^{\\frac12}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000418>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Exponential 1" , "Negative exponential"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Exponential 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Exponential1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000419> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000420> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0000422> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0000421> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000423> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000424> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000425> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000426> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000427> .
+
+<http://www.probonto.org/ontology#PROB_k0001227>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Maxwell Boltzmann 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Maxwell Boltzmann 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sqrt{2} a"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000065>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Beta 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Beta 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\alpha\\beta}{(\\alpha+\\beta)^2(\\alpha+\\beta+1)}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000718>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "dispersion of Generalized-Poisson-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "dispersion of Generalized-Poisson-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedPoisson1.dispersion"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\delta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "max(-1,-\\theta/m) < \\delta < 1 \\text{ with } m (\\geq 4) \\text { the largest positive integer for which } \\theta + m \\delta > 0 \\text{ when } \\delta < 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "dispersion"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "dispersion"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001334>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale parameter of Johnson-SU-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale parameter of Johnson-SU-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSU1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000872>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Normal 2 and Normal 3 whereby \\\\mu = \\\\mu, 
+\\\\tau = 1 / v""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000265> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000290> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """\\mu = \\mu, 
+\\tau = 1 / v"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Normal2(\\mu,v) \\rightarrow Normal3(\\mu,\\tau)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000231>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "category probabilities of Categorical-Ordered-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "category probabilities of Categorical-Ordered-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "CategoricalOrdered1.categoryProb"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "p_1, \\ldots, p_k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "0 \\leq p_i \\leq 1, \\Sigma p_i = 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "category probabilities"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "categoryProb"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000419>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Exponential 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Exponential 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lambda e^{-\\lambda x}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "lambda*exp(-lambda*x)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001290>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Zipf 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Zipf 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(H_{n,\\alpha-2}  H_{n,\\alpha} -  H_{n,\\alpha-1}^2)/ H_{n,\\alpha}^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000657>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Multinomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Multinomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "E\\{X_i\\} = np_i"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000853>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Normal 1 and Normal 2 whereby \\\\mu = \\\\mu, 
+v = \\\\sigma^2 """ ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000265> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """\\mu = \\mu, 
+v = \\sigma^2 """^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Normal1(\\mu,\\sigma) \\rightarrow Normal2(\\mu,v)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001313>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Epanechnikov 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Epanechnikov 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac15"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000145>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Zero-Inflated Negative Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Zero-Inflated Negative Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000018>
+      a       owl:Class ;
+      rdfs:label "variate" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000005> .
+
+<http://www.probonto.org/ontology#PROB_k0000348>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Dirichlet 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Dirichlet 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "E[X_i] = \\frac{\\alpha_i}{\\sum_k \\alpha_k}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000009>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Gompertz 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Gompertz 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "b\\eta e^{bx}e^{\\eta}\\exp\\left(-\\eta e^{bx} \\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "b*eta*exp(b*x)*exp(eta)*exp(-eta*exp(b*x))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001090>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape  of LKJ-Correlation-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape  of LKJ-Correlation-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LKJCorrelation2.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\eta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\eta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001377>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Standard Triangular 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Standard Triangular 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000025>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Weibull 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Weibull 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "v\\lambda \\,x^{v-1}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "v*lambda * x^(v-1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000543>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Inverse Weibull"^^<en> , "Frechet 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Frechet 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Frechet2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000544> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000545> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000546> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000547> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000548> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000549> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (m, \\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000550> , <http://www.probonto.org/ontology#PROB_k0000551> , <http://www.probonto.org/ontology#PROB_k0000552> .
+
+<http://www.probonto.org/ontology#PROB_k0000738>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of GeneralizedPoisson2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of GeneralizedPoisson2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000873>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label "relationship between Inverse Gaussian 1 and Standard Normal 1 whereby \\\\lambda \\\\rightarrow \\\\infty " ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000212> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000562> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\lambda \\rightarrow \\infty "^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "InverseGaussian1(\\lambda,\\mu) \\rightarrow StandardNormal1(0,1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/InversegaussianStandardnormal.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000758>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Generalized Poisson 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Generalized Poisson 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedPoisson3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000759> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000760> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000761> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000762> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "y"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "y \\in \\{0,1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000764> , <http://www.probonto.org/ontology#PROB_k0000763> .
+
+<http://www.probonto.org/ontology#PROB_k0000045>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Nakagami 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Nakagami 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sqrt{\\Omega}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000038>
+      a       owl:ObjectProperty ;
+      rdfs:label "distribution has PMF" .
+
+<http://www.probonto.org/ontology#PROB_k0001226>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Maxwell Boltzmann 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Maxwell Boltzmann 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "2a \\sqrt{\\frac{2}{\\pi}}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000064>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Beta 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Beta 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\alpha-1}{\\alpha+\\beta-2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000320>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "lambda of Normal-inverse-gamma-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "lambda of Normal-inverse-gamma-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NormalInverseGamma1.lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\lambda > 0, \\lambda \\in  R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "lambda"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000717>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "Poisson intensity of Generalized-Poisson-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Poisson intensity of Generalized-Poisson-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedPoisson1.rate"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\theta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\theta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "Poisson intensity"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "rate"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000696>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape1 of Generalized-Negative-Binomial-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape1 of Generalized-Negative-Binomial-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedNegativeBinomial1.beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta = 0 \\text{ or } 1 \\le \\beta \\le \\theta^{-1}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "beta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001333>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location parameter of Johnson-SU-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location parameter of Johnson-SU-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSU1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000083>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Wishart 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Wishart 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{|X|^{\\frac{n-p-1}{2}} e^{-\\frac{\\text{tr}(V^{-1}X)}{2}}}{2^\\frac{np}{2}|V|^\\frac{n}{2}\\Gamma_p(\\frac{n}{2})}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000671>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Generalized Gamma 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Generalized Gamma 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\beta}{\\Gamma(r)}\\mu^{\\beta r}x^{\\beta r -1}\\exp[-(\\mu x)^\\beta]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "beta / gamma(r) * mu^(beta*r) * x^(beta*r -1) * exp(-(mu*x)^beta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000658>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Multinomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Multinomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """Var(X_i) = n p_i (1-p_i); \\quad
+Cov(X_i,X_j) = - n p_i p_j~~(i\\neq j)"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000850>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Weibull 1 and Exponential 1 whereby k=1, \\\\lambda_{Exponetial} = 1/\\\\lambda" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000800> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000418> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "k=1, \\lambda_{Exponetial} = 1/\\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Weibull1(\\lambda,k) \\rightarrow Exponential1(\\lambda_{Exponetial})"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{forbes2011statistical}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000345>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Dirichlet 1" , "Dirichlet"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Dirichlet 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Dirichlet1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000346> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000348> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000349> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000350> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x_1, \\cdots, x_K \\quad\\text{where}\\quad x_i \\in [0,1]\\quad and \\quad\\sum_{i=1}^K x_i = 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000351> .
+
+<http://www.probonto.org/ontology#PROB_k0000458>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Log-Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Log-Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "e^{\\mu-v}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001091>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "non-standardized Student's t-distribution"^^<en> , "t Location-Scale"^^<en> , "Student's t-distribution 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Student's t-distribution 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StudentT3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001092> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001094> , <http://www.probonto.org/ontology#PROB_k0001093> , <http://www.probonto.org/ontology#PROB_k0001095> .
+
+<http://www.probonto.org/ontology#PROB_k0001400>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Levy-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Levy-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Levy1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000022>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Weibull 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Weibull 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Weibull2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000023> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000024> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0001076> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0000025> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000026> , <http://www.probonto.org/ontology#PROB_k0000027> .
+
+<http://www.probonto.org/ontology#PROB_k0000006>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Bernoulli 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Bernoulli 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "p(1-p)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001316>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Johnson SL 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Johnson SL 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+\\frac12 \\text{erfc}\\left[-\\frac{\\gamma + \\delta \\,\\log\\left[\\frac{x-\\mu}{\\sigma}\\right]}{\\sqrt{2}}\\right] & \\text{for } \\mu < x \\le \\mu + \\sigma \\\\ 
+\\frac12\\left(1+  \\text{erf}\\left[\\frac{\\gamma + \\delta \\,\\log\\left[\\frac{x-\\mu}{\\sigma}\\right]}{\\sqrt{2}}\\right] \\right) & \\text{for } x > \\mu + \\sigma
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """CDF1=1/2*erfc(-(gamma+delta*log((x-mu)/sigma))/sqrt(2))
+CDF2=1/2*(1+ erf((gamma+delta*log((x-mu)/sigma))/sqrt(2)))"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000144>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Zero-Inflated Negative Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Zero-Inflated Negative Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Sigma_{i=1}^x f(i), x \\in \\{0,1,2,...\\} \\text{ with } f \\text{ the PMF}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "c(PMF1,cumsum(PMF2)+PMF1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001420>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Standard Uniform 1 and Standard Power 1 whereby \\\\text{If } X \\\\sim \\\\text{ StandardUniform1, then } Y = X^{1/\\\\beta} \\\\text{ has the StandardPower}\\\\beta \\\\text{ distribution, where } \\\\beta > 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000587> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001351> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X \\sim \\text{ StandardUniform1, then } Y = X^{1/\\beta} \\text{ has the StandardPower}(\\beta) \\text{ distribution, where } \\beta > 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StandardUniform1 \\rightarrow StandardPower1(\\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/StandarduniformStandardpowerB.pdf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000630>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Mixture Distribution 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Mixture Distribution 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MixtureDistribution1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000631> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000634> .
+
+<http://www.probonto.org/ontology#PROB_k0000759>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Generalized Poisson 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Generalized Poisson 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Big( \\frac{\\mu}{1+\\alpha \\mu}\\Big)^y \\frac{(1+\\alpha y)^{y-1}}{y!} \\exp\\Big[ \\frac{-\\mu (1+\\alpha y)}{1+\\alpha \\mu}\\Big]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(mu/(1+alpha*mu))^y *(1+alpha*y)^(y-1)/factorial(y)*exp(-mu*(1+alpha*y)/(1+alpha*mu))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000042>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Nakagami 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Nakagami 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{2m^m}{\\Gamma(m)\\Omega^m}x^{2m-1} \\exp(-\\frac{m}{\\omega}x^2)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "2*m^m / (gamma(m)*Omega^m)*x^(2*m-1)*exp(-m/Omega*x^2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001352>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Standard Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Standard Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\beta x^{\\beta-1}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(beta * x^(beta-1))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000739>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of GeneralizedPoisson2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of GeneralizedPoisson2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\mu}{(1 -\\delta)^2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000546>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Frechet 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Frechet 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+   \\ m+\\sigma\\Gamma\\left(1-\\frac{1}{\\alpha}\\right)  & \\text{for } \\alpha>1  \\\\
+   \\ \\infty              & \\text{otherwise}
+\\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000699>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Multivariate Gaussian Process Distribution 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Multivariate Gaussian Process Distribution 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\prod^K_{i=1} \\text{MultivariateNormal1}(x_i|0,w^{-1}_i LL^T)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001139>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Benford 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Benford 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\approx 3.4402"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001336>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Standard Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Standard Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1 - \\frac12 \\text{erfc}\\left(-\\frac{x}{\\sqrt{2}}\\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1 - 1/2 *erfc(-x/sqrt(2))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000082>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Wishart 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Wishart 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Wishart1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000083> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000085> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000086> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000087> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "X"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "X(p \\times p) - \\text{positive definite matrix}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000088> , <http://www.probonto.org/ontology#PROB_k0000089> .
+
+<http://www.probonto.org/ontology#PROB_k0000870>
+      a       <http://www.probonto.org/ontology#PROB_c0000078> ;
+      rdfs:label "relationship between Binomial 1 and Normal 1 whereby \\\\text{For } X \\\\sim Binomial1n,p \\\\text{ as } n \\\\rightarrow \\\\infty, X \\\\text{ is approximately normally distributed } \\\\\\\\Normal1\\\\mu,\\\\sigma \\\\text{ with } \\\\mu=np, \\\\sigma=np1-p." ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000117> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000239> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{For } X \\sim Binomial1(n,p) \\text{ as } n \\rightarrow \\infty, X \\text{ is approximately normally distributed } \\\\Normal1(\\mu,\\sigma) \\text{ with } \\mu=np, \\sigma=np(1-p)."^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Binomial1(n,p) \\rightarrow Normal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{Leemis:2008tg} \\\\ \\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/BinomialNormal.pdf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001390>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Folded Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Folded Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\mu^2 + \\sigma^2 - \\Big(\\sigma \\sqrt{\\tfrac{2}{\\pi}} \\, e^{(-\\mu^2/2\\sigma^2)} + \\mu \\left(1 - 2\\,\\Phi(\\tfrac{-\\mu}{\\sigma}) \\right)\\Big)^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000499>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degree of freedom of F-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degree of freedom of F-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "F1.denominator"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "n_2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "n_2 > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degree of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "denominator"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001225>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Maxwell Boltzmann 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Maxwell Boltzmann 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\text{erf}\\left(\\frac{x}{\\sqrt{2} a}\\right) -\\sqrt{\\frac{2}{\\pi}} \\frac{x e^{-x^2/\\left(2a^2\\right)}}{a}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "erf(x/(sqrt(2)*a)) -sqrt(2/pi) * (x * exp(-x^2/(2*a^2)) )/a"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000063>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Beta 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Beta 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "I_{\\frac{1}{2}}^{[-1]}(\\alpha,\\beta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000659>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "number of trials of Multinomial-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "number of trials of Multinomial-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Multinomial1.numberOfTrials"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "n"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "n > 0, n \\in N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "number of trials"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "numberOfTrials"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000061>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Beta 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Beta 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1-I_x(\\alpha,\\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1 - Rbeta(x, alpha, beta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001379>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Standard Two-Sided Power 1" , "STSP"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Standard Two-Sided Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StandardTwoSidedPower1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001380> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001381> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001382> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001383> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001384> , <http://www.probonto.org/ontology#PROB_k0001385> .
+
+<http://www.probonto.org/ontology#PROB_k0000670>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Generalized Gamma 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Generalized Gamma 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedGamma3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000671> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000675> , <http://www.probonto.org/ontology#PROB_k0000674> , <http://www.probonto.org/ontology#PROB_k0000673> .
+
+<http://www.probonto.org/ontology#PROB_k0001401>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Levy-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Levy-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Levy1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "c"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "c > 0, c \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000023>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Weibull 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Weibull 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "v\\lambda \\,x^{v-1} e^{-\\lambda x^{v}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "v*lambda * x^(v-1) * exp(-lambda * x^v)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000346>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Dirichlet 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Dirichlet 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{B(\\alpha)} \\prod_{i=1}^K x_i^{\\alpha_i - 1} \\\\ \\text{ where} \\quad B(\\alpha) = \\frac{\\prod_{i=1}^K \\Gamma(\\alpha_i)}{\\Gamma\\bigl(\\sum_{i=1}^K \\alpha_i\\bigr)} \\\\ \\text{ where} \\quad \\alpha=(\\alpha_1,\\ldots,\\alpha_K)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000459>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Log-Normal 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Log-Normal 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(e^v-1) e^{2\\mu+v}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000143>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Zero-Inflated Negative Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Zero-Inflated Negative Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+p0 + (1-p0) \\Big(\\frac{1}{1 + \\tau\\lambda} \\Big)^{1/\\tau} & \\text{for } y = 0 \\\\ 
+(1-p0) \\frac{\\Gamma(y+1/\\tau)}{y!\\Gamma(1/\\tau)} \\Big(\\frac{1}{1 + \\tau\\lambda} \\Big)^{1/\\tau} 
+\\Big(\\frac{\\lambda}{1/\\tau + \\lambda} \\Big)^{y} & \\text{for } y > 0
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """PMF1=p0 + (1-p0) * (1/ (1 + tau * lambda))^(1/tau) # for y=0
+PMF2=(1-p0) * gamma(y+1/tau) / (factorial(y) *gamma(1/tau)) 
+* (1/(1 + tau*lambda))^(1/tau) * (lambda/(1/tau + lambda))^y # for y>0"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000851>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 1 and Negative Binomial 5 whereby \\\\alpha = r, \\\\beta = p / 1-p" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000074> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000190> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\alpha = r, \\beta = p / (1-p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial1(r,p) \\rightarrow NegativeBinomial5(\\alpha, \\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000007>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "probability of success of Bernoulli-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "probability of success of Bernoulli-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Bernoulli1.probability"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "0<p<1, p \\in  R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "probability of success"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "probability"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001315>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Johnson SL 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Johnson SL 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{e^{-\\frac12 \\left( \\gamma + \\delta \\log\\left[\\frac{x-\\mu}{\\sigma}\\right]\\right)^2} \\delta}{\\sqrt{2\\pi} (x-\\mu)}\\\\"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp(-1/2*(gamma+delta*log((x-mu)/sigma))^2)*delta/(sqrt(2*pi)*(x-mu))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001092>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Student's t-distribution 3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Student's t-distribution 3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\Gamma \\left(\\frac{\\nu+1}{2} \\right)}{\\Gamma \\left(\\frac{\\nu}{2} \\right)} \\frac{1}{\\sqrt{\\nu\\pi} \\sigma} \\left(1+\\frac{1}{\\nu} \\left(\\frac{x-\\mu}{\\sigma}\\right)^2 \\right)^{-\\frac{\\nu+1}{2}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "gamma((nu+1)/2)/gamma(nu/2)*1/sqrt(nu*pi)/sigma*(1+1/nu*((x-mu)/sigma)^2)^(-(nu+1)/2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001421>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Standard Uniform 1 and Benford 1 whereby \\\\text{If } X \\\\sim \\\\text{StandardUniform1, then } Y = \\\\lfloor 10^X \\\\rfloor \\\\text{ has the Benford1 distribution}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000587> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001134> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\text{If } X \\sim \\text{StandardUniform1, then } Y = \\lfloor 10^X \\rfloor \\text{ has the Benford1 distribution}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "StandardUniform1 \\rightarrow Benford1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/StandarduniformBenford.pdf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001224>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Maxwell Boltzmann 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Maxwell Boltzmann 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sqrt{\\frac{2}{\\pi}} \\frac{x^2 e^{-x^2/\\left(2a^2\\right)}}{a^3}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "sqrt(2/pi) * (x^2 * exp(-x^2/(2*a^2)) )/a^3"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001335>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Standard Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Standard Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\sqrt{\\frac2\\pi}}{e^{\\frac{x^2}{2}} \\left(2-\\text{erfc}\\left(\\frac{-x}{\\sqrt{2}}\\right)\\right)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "sqrt(2/pi)/(exp(x^2/2)*(2-erfc(-x/sqrt(2))))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000498>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degree of freedom of F-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degree of freedom of F-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "F1.numerator"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "n_1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "n_1 > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degree of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "numerator"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000545>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Frechet 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Frechet 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\exp\\Big(-\\Big(\\frac{\\sigma}{x-m}\\Big)^\\alpha\\Big)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp(-(sigma/(x-m))^alpha)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000698>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Cholesky parameterization"^^<en> , "Multivariate Gaussian Process Distribution"^^<en> , "Multivariate Gaussian Process Distribution 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Multivariate Gaussian Process Distribution 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateGaussianProcess2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000699> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in R^{K\\times N}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000701> , <http://www.probonto.org/ontology#PROB_k0000702> .
+
+<http://www.probonto.org/ontology#PROB_k0000043>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Nakagami 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Nakagami 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\gamma(m,\\frac{m}{\\Omega}x^2)}{\\Gamma(m)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "Igamma(m,m/Omega*x^2,lower=T)/gamma(m)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001351>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Standard Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Standard Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StandardPower1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001352> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001353> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0001355> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0001354> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001356> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0001357> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001358> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001359> .
+
+<http://www.probonto.org/ontology#PROB_k0000081>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "success probability of Negative-Binomial-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "success probability of Negative-Binomial-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial1.probability"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "p \\in (0,1)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "success probability"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "probability"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000871>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 1 and Negative Binomial 4 whereby p = 1 -p" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000074> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000161> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "p = 1 -p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial1(r,p) \\rightarrow NegativeBinomial4(r,p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001391>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "location of Folded-Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "location of Folded-Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "FoldedNormal1.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000062>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Beta 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Beta 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\alpha}{\\alpha+\\beta}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000719>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Multivariate Normal 1" , "Multivariate Gaussian 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Multivariate Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateNormal1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000720> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000721> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000722> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000723> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000724> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "-\\infty < x_i < \\infty, i = 1,...,k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000726> , <http://www.probonto.org/ontology#PROB_k0000725> .
+
+<http://www.probonto.org/ontology#PROB_k0000631>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Mixture Distribution 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Mixture Distribution 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "f(x; \\pi, \\theta) = \\sum_{i=1}^{K} \\pi_{i}\\; p_i(x; \\theta_i) \\text{ where } p_i(x; \\theta_i) \\text{ the PDF of the } i^{th} \\text{ component with parameters } \\theta_i"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000020>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "precision matrix of Multivariate-Student-T-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "precision matrix of Multivariate-Student-T-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateStudentT2.precisionMatrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "T"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\text{Inverse of the covariance matrix}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "precision matrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "precisionMatrix"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001374>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Standard Triangular 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Standard Triangular 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+-\\frac12 x^2-x+\\frac12 & \\text{ for } -1 < x < 0 \\\\
+\\frac12 x^2-x+\\frac12 & \\text{ for } 0 \\leq x < 1
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """SF1=-1/2*x^2-x+1/2
+SF2=1/2*x^2-x+1/2"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001093>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degrees of freedom of Student-s-t-distribution-3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degrees of freedom of Student-s-t-distribution-3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StudentT3.degreesOfFreedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\nu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\nu > 0, \\nu \\in  R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degrees of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "degreesOfFreedom"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000608>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Lomax 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Lomax 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lambda (\\sqrt[\\alpha]{2} - 1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000568>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Standard Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Standard Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000920>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 1 and Log-Normal 3 whereby m = \\\\exp\\\\mu, \\\\sigma = \\\\sigma" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000428> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000478> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "m = \\exp(\\mu), \\sigma = \\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal1(\\mu,\\sigma) \\rightarrow LogNormal3(m,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000004>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Bernoulli 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Bernoulli 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+0 & \\text{if } q > p\\\\
+0.5 & \\text{if } q=p\\\\
+1 & \\text{if } q<p
+\\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000733>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "minimum of Uniform-Discrete-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "minimum of Uniform-Discrete-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "UniformDiscrete1.minimum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "a \\in \\{\\dots,-2,-1,0,1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "minimum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "minimum"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000015>
+      a       owl:Class ;
+      rdfs:label "scalar" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000005> .
+
+<http://www.probonto.org/ontology#PROB_k0000142>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Zero-Inflated Negative Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Zero-Inflated Negative Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ZeroInflatedNegativeBinomial1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000143> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000144> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000145> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000147> , <http://www.probonto.org/ontology#PROB_k0000148> , <http://www.probonto.org/ontology#PROB_k0000146> .
+
+<http://www.probonto.org/ontology#PROB_k0000652>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape1 of Generalized-Gamma-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape1 of Generalized-Gamma-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedGamma2.shape1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "c"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "c > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000343>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "ordered cutpoints of Ordered-Logistic-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "ordered cutpoints of Ordered-Logistic-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "OrderedLogistic1.cutpoint"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "c"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "c \\in R^{K-1} \\mbox{ such that } c_k < c_{k-1} \\text{ for } k \\in \\{1,...,K-2\\}, K \\in N, K>2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "ordered cutpoints"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "cutpoint"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001393>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Levy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Levy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Levy1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001394> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001395> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001396> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0001397> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0001398> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001399> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in [\\mu,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001401> , <http://www.probonto.org/ontology#PROB_k0001400> .
+
+<http://www.probonto.org/ontology#PROB_k0000060>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Beta 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Beta 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{x^{\\alpha-1}(1-x)^{\\beta-1}} {(1-I_x(\\alpha,\\beta)) B(\\alpha,\\beta)}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "(x^(alpha-1) * (1-x)^(beta-1))/((1-Rbeta(x,alpha,beta))*beta(alpha,beta))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000673>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Generalized-Gamma-3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Generalized-Gamma-3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedGamma3.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "r"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "r > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000089>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degrees of freedom of Wishart-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degrees of freedom of Wishart-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Wishart1.degreesOfFreedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "n"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "n > p-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degrees of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "degreesOfFreedom"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001310>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Epanechnikov 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Epanechnikov 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac34 (1-x^2)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "3/4 * (1-x^2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000632>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Mixture Distribution 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Mixture Distribution 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "f(x; \\pi, \\theta) = \\sum_{i=1}^{K} \\pi_{i}\\; p_i(x; \\theta_i) \\text{ where } p_i(x; \\theta_i) \\text{ the PMF of the } i^{th} \\text{ component with parameters } \\theta_i"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000962>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Laplace 2 and Laplace 1 whereby b=1/\\\\tau" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000283> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000256> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "b=1/\\tau"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Laplace2(\\mu,\\tau) \\rightarrow Laplace1(\\mu,b)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000048>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Nakagami-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Nakagami-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Nakagami1.shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "m"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "m > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000693>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Generalized Negative Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Generalized Negative Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "m \\theta (1-\\theta \\beta)^{-1}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001392>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Folded-Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Folded-Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "FoldedNormal1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma> 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001338>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Johnson SN 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Johnson SN 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{e^{-\\frac12 \\left( \\gamma + \\frac{\\delta (x-\\mu)}{\\sigma}\\right)^2} \\delta}{\\sqrt{2\\pi}\\sigma}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "exp(-1/2*(gamma+(delta*(x-mu))/sigma)^2)*delta/(sqrt(2*pi)*sigma)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000122>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lfloor (n + 1)p \\rfloor \\; or \\; \\lfloor (n + 1)p \\rfloor - 1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000876>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Uniform Discrete 1 and Uniform Discrete 2 whereby a = 0, b = n" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000727> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000750> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "a = 0, b = n"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "UniformDiscrete1(a,b) \\rightarrow UniformDiscrete2(n)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              """\\cite{Leemis:2008tg} \\\\ 
+\\url{http://www.math.wm.edu/~leemis/chart/UDR/PDFs/DiscreteuniformRectangular.pdf}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000323>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Conway-Maxwell-Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Conway-Maxwell-Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ConwayMaxwellPoisson1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000324> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000325> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000326> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0000327> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000328> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in \\{0,1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000330> , <http://www.probonto.org/ontology#PROB_k0000329> .
+
+<http://www.probonto.org/ontology#PROB_k0000548>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Frechet 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Frechet 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "m+\\sigma\\left(\\frac{\\alpha}{1+\\alpha}\\right)^{1/\\alpha}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001354>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Standard Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Standard Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\beta x^{\\beta-1}}{1 - x^\\beta}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "beta * x^(beta-1) / (1 - x^beta)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001422>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Logistic 1 and Standard Logistic 1 whereby \\\\mu = 0, s = 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000307> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001321> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = 0, s = 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Logistic1(\\mu,s) \\rightarrow StandardLogistic1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000005>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Bernoulli 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Bernoulli 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+0 & \\text{if } q > p\\\\
+0, 1 & \\text{if } q=p\\\\
+1 & \\text{if } q < p
+\\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001094>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Student-s-t-distribution-3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Student-s-t-distribution-3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StudentT3.location"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "location"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001036>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "standard deviation of Log-Normal-7" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "standard deviation of Log-Normal-7"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal7.stdev"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma_N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\sigma_N > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "standard deviation"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "stdev"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000609>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Lomax 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Lomax 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000567>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Standard Normal 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Standard Normal 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000021>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degrees of freedom of Multivariate-Student-T-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degrees of freedom of Multivariate-Student-T-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MultivariateStudentT2.degreesOfFreedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "k \\ge 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degrees of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "degreesOfFreedom"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001373>
+      a       <http://www.probonto.org/ontology#PROB_c0000027> ;
+      rdfs:label "HF of Standard Triangular 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "HF of Standard Triangular 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+\\frac{2(x+1)}{-x^2-2x+1} & \\text{ for } -1 < x < 0 \\\\
+\\frac2{1-x} & \\text{ for } 0 \\leq x < 1
+\\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """HF1=(2*(x+1))/(-x^2-2*x+1) for -1 < x < 0 
+HF2=2/(1-x) for 0 \\leq x < 1"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000734>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "maximum of Uniform-Discrete-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "maximum of Uniform-Discrete-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "UniformDiscrete1.maximum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "b"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "b \\in \\{\\dots,-2,-1,0,1,2,3,\\dots\\}, b \\ge a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "maximum"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "maximum"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000141>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "index parameter of Negative-Binomial-3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "index parameter of Negative-Binomial-3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial3.dispersion"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\phi"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\phi \\in R, \\phi > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "index parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "dispersion"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000149>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Binomial distribution with logit parameterisation"^^<en> , "Binomial 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Binomial 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Binomial2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000150> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000151> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,\\dots,n\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000153> , <http://www.probonto.org/ontology#PROB_k0000152> .
+
+<http://www.probonto.org/ontology#PROB_k0001394>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Levy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Levy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sqrt{\\frac{c}{2\\pi}} \\frac{e^{-\\frac{c}{2(x-\\mu)}}}{(x-\\mu)^{3/2}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "sqrt(c/2/pi) * exp(-c/2/(x-mu)) / (x-mu)^(3/2)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000344>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "predictor of Ordered-Logistic-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "predictor of Ordered-Logistic-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "OrderedLogistic1.predictor"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\eta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\eta \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "predictor"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "predictor"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000653>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape2 of Generalized-Gamma-2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape2 of Generalized-Gamma-2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedGamma2.shape2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "k > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000088>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale matrix of Wishart-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale matrix of Wishart-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Wishart1.scaleMatrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "V"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "V > 0, p\\times p - \\text{positive definite matrix}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale matrix"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scaleMatrix"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000049>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "spread of Nakagami-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "spread of Nakagami-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Nakagami1.spread"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\Omega"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\Omega > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "spread"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "spread"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000961>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Log-Normal 6 and Log-Normal 5 whereby \\\\mu=\\\\logm, 
+\\\\tau= 1/\\\\log^2 \\\\sigma_g""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000553> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000526> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """\\mu=\\log(m), 
+\\tau= 1/\\log^2 (\\sigma_g)"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal6(m,\\sigma_g) \\rightarrow LogNormal5(\\mu,\\tau)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000692>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Generalized Negative Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Generalized Negative Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Sigma_{i=1}^x f(i), x \\in \\{0,1,2,...\\} \\text{ with } f \\text{ the PMF}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "cumsum(PMF)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001423>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Logistic 2 and Standard Logistic 1 whereby \\\\mu = 0, \\\\tau = 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000331> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001321> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu = 0, \\tau = 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Logistic2(\\mu,\\tau) \\rightarrow StandardLogistic1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000014>
+      a       owl:Class ;
+      rdfs:label "interval" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000006> .
+
+<http://www.probonto.org/ontology#PROB_k0000121>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\lfloor np \\rfloor \\text{ or } \\lceil np \\rceil"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001337>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Johnson SN 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Johnson SN 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "JohnsonSN1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001338> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001339> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0001342> , <http://www.probonto.org/ontology#PROB_k0001341> , <http://www.probonto.org/ontology#PROB_k0001343> , <http://www.probonto.org/ontology#PROB_k0001340> .
+
+<http://www.probonto.org/ontology#PROB_k0001353>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Standard Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Standard Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "x^\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "x^beta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000547>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Frechet 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Frechet 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "m+\\frac{\\sigma}{\\sqrt[\\alpha]{\\log_e(2)}}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000877>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Normal 3 and Normal 2 whereby \\\\mu = \\\\mu, 
+v = 1 / \\\\tau""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000290> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000265> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """\\mu = \\mu, 
+v = 1 / \\tau"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "Normal3(\\mu,\\tau) \\rightarrow Normal2(\\mu,v)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000324>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Conway-Maxwell-Poisson 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Conway-Maxwell-Poisson 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\lambda^x}{(x!)^\\nu}\\frac{1}{Z(\\lambda,\\nu)} \\text{ with } Z(\\lambda,\\nu) = \\sum_{j=0}^\\infty \\frac{\\lambda^j}{(j!)^\\nu}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """lambda^x/(factorial(x))^nu*1/Z(lambda,nu,n); 
+ Z(lambda,nu,n): for(i in 0:n) { Z=Z+lambda^i/(factorial(i))^nu }}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000735>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "GeneralizedPoisson2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "GeneralizedPoisson2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedPoisson2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000736> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0000737> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000738> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000739> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "k \\in \\{0,1,2,3,\\dots\\}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000740> , <http://www.probonto.org/ontology#PROB_k0000741> .
+
+<http://www.probonto.org/ontology#PROB_k0001376>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "median of Standard Triangular 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "median of Standard Triangular 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000148>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "probability of zero of Zero-Inflated-Negative-Binomial-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "probability of zero of Zero-Inflated-Negative-Binomial-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ZeroInflatedNegativeBinomial1.probabilityOfZero"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "p0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "0<p0<1, p0 \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "probability of zero"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "probabilityOfZero"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000017>
+      a       owl:Class ;
+      rdfs:label "mathematical function" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000005> .
+
+<http://www.probonto.org/ontology#PROB_k0000140>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Negative-Binomial-3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Negative-Binomial-3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NegativeBinomial3.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R, \\mu > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000922>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 2 and Negative Binomial 3 whereby \\\\mu=\\\\lambda, \\\\phi=1/\\\\tau" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000105> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000135> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\mu=\\lambda, \\phi=1/\\tau"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial2(\\lambda, \\tau) \\rightarrow NegativeBinomial3(\\mu, \\phi)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000675>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Generalized-Gamma-3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Generalized-Gamma-3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedGamma3.shape2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001035>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of x of Log-Normal-7" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of x of Log-Normal-7"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "LogNormal7.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu_N"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu_N \\in R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean of x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001095>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Student-s-t-distribution-3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Student-s-t-distribution-3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StudentT3.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\sigma"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu \\in R^{+}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001312>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Epanechnikov 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Epanechnikov 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000002>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Bernoulli 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Bernoulli 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+    q=(1-p) & \\text{for }k=0 \\\\ p & \\text{for }k=1
+    \\end{cases}"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              """q=(1-p) for k=0 
+p for k=1"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000654>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Multinomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Multinomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Multinomial1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000038>
+              <http://www.probonto.org/ontology#PROB_k0000655> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000657> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000658> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "X"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "X_i \\in \\{0,\\dots,n\\}, \\Sigma X_i = n"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000659> , <http://www.probonto.org/ontology#PROB_k0000660> .
+
+<http://www.probonto.org/ontology#PROB_k0000341>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Ordered Logistic 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Ordered Logistic 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+1 - logit^{-1}(\\eta - c_1) & \\text{for }k=1 \\\\ 
+logit^{-1}(\\eta - c_{k-1}) - logit^{-1}(\\eta - c_k) & \\text{for }1<k<K \\\\
+logit^{-1}(\\eta - c_{k-1}) & \\text{for }k=K
+\\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001249>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "degrees of freedom of Chi-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "degrees of freedom of Chi-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Chi1.degreesOfFreedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "k > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "degrees of freedom"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "degreesOfFreedom"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001395>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Levy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Levy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\textrm{erfc}\\left(\\sqrt{\\frac{c}{2(x-\\mu)}}\\right)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "erfc(sqrt(c/2/(x-mu)))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000087>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Wishart 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Wishart 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "Var(X_{ij}) = n \\left (v_{ij}^2+v_{ii}v_{jj} \\right )"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000695>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Generalized-Negative-Binomial-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Generalized-Negative-Binomial-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedNegativeBinomial1.theta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\theta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "0 < \\theta < 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "theta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001229>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale parameter of Maxwell-Boltzmann-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale parameter of Maxwell-Boltzmann-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MaxwellBoltzmann1.scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "a"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "a > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale parameter"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "scale"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001424>
+      a       <http://www.probonto.org/ontology#PROB_c0000066> ;
+      rdfs:label "relationship between Noncentral F 1 and Noncentral chi-squared 1 whereby F \\\\sim NoncentralF1\\\\lambda,m,n \\\\text{, as } n \\\\rightarrow \\\\infty \\\\text{ then } nF \\\\text{ approaches a non-central chi-square distribution with }  m \\\\text{ degrees of freedom and non-central parameter } \\\\lambda" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001143> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0001127> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "F \\sim NoncentralF1(\\lambda,m,n) \\text{, as } n \\rightarrow \\infty \\text{ then } nF \\text{ approaches a non-central chi-square distribution with }  m \\text{ degrees of freedom and non-central parameter } \\lambda"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NoncentralF1(\\lambda,m,n) \\rightarrow NoncentralChiSquared1(m,\\lambda)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{walck2007handbook}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000321>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Normal-inverse-gamma-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Normal-inverse-gamma-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NormalInverseGamma1.alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\alpha"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\alpha > 0, \\alpha \\in  R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "alpha"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000634>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mixing coefficients of Mixture-Distribution-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mixing coefficients of Mixture-Distribution-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "MixtureDistribution1.weight"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\pi_1, \\ldots, \\pi_k"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\Sigma_{i=1}^K \\pi_i=1; 0\\le \\pi_i \\le 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mixing coefficients"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "weight"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000960>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Log-Normal 2 and Log-Normal 4 whereby m = \\\\exp\\\\mu, cv = \\\\sqrt{\\\\expv - 1}" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000453> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000500> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "m = \\exp(\\mu), cv = \\sqrt{\\exp(v) - 1}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal2(\\mu,v) \\rightarrow LogNormal4(m,cv)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000120>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "np"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001096>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "Arcsine 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Arcsine 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "Arcsine1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0001097> ;
+      <http://www.probonto.org/ontology#PROB_c0000039>
+              <http://www.probonto.org/ontology#PROB_k0001098> ;
+      <http://www.probonto.org/ontology#PROB_c0000040>
+              <http://www.probonto.org/ontology#PROB_k0001100> ;
+      <http://www.probonto.org/ontology#PROB_c0000041>
+              <http://www.probonto.org/ontology#PROB_k0001099> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0001101> ;
+      <http://www.probonto.org/ontology#PROB_c0000043>
+              <http://www.probonto.org/ontology#PROB_k0001102> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0001103> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0001104> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (0,1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000046>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Nakagami 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Nakagami 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\sqrt{2}}{2} \\Big(\\frac{(2m-1)\\Omega}{m} \\Big)^{1/2}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001356>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Standard Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Standard Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\beta/(\\beta+1)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000874>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Generalized Negative Binomial 1 and Binomial 1 whereby \\\\beta=0 \\\\text{ and set } m=n, \\\\theta=p" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000690> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000117> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\beta=0 \\text{ and set } m=n, \\theta=p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "GeneralizedNegativeBinomial1(\\theta,\\beta,m) \\rightarrow Binomial1(n,p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{Consul:2006qf}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000569>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Standard-Normal-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Standard-Normal-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StandardNormal1.mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu=0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "mean"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "mean"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000921>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label """relationship between Log-Normal 6 and Log-Normal 1 whereby \\\\mu=\\\\logm, 
+\\\\sigma=\\\\log\\\\sigma_g""" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000553> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000428> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              """\\mu=\\log(m), 
+\\sigma=\\log(\\sigma_g)"""^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "LogNormal6(m,\\sigma_g) \\rightarrow LogNormal1(\\mu,\\sigma)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000736>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of GeneralizedPoisson2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of GeneralizedPoisson2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{\\mu (1-\\delta) [\\mu(1-\\delta)+\\delta k]^{k-1}}{k!} e^{-[\\mu (1-\\delta) + \\delta k]}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "-(mu*(1-delta)*(mu*(1-delta)+delta*k)^(k-1)) / factorial(k) * exp(-(mu*(1-delta)+delta*k))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001375>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Standard Triangular 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Standard Triangular 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "0"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000147>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "overdispersion of Zero-Inflated-Negative-Binomial-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "overdispersion of Zero-Inflated-Negative-Binomial-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "ZeroInflatedNegativeBinomial1.overdispersion"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\tau"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "overdispersion"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "overdispersion"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_c0000016>
+      a       owl:Class ;
+      rdfs:label "matrix" ;
+      rdfs:subClassOf <http://www.probonto.org/ontology#PROB_c0000005> .
+
+<http://www.probonto.org/ontology#PROB_k0001034>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Log-Normal 7" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Log-Normal 7"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\sigma_N^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000674>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "shape of Generalized-Gamma-3" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "shape of Generalized-Gamma-3"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "GeneralizedGamma3.shape1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\mu"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\mu > 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "shape"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "shape1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001311>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Epanechnikov 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Epanechnikov 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "-\\frac14 x^3 + \\frac34 x + \\frac12"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "-1/4*x^3 + 3/4*x + 1/2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000003>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Bernoulli 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Bernoulli 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "p"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000655>
+      a       <http://www.probonto.org/ontology#PROB_c0000024> ;
+      rdfs:label "PMF of Multinomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PMF of Multinomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{n!}{x_1!\\cdots x_k!} p_1^{x_1} \\cdots p_k^{x_k}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001248>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Chi 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Chi 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "k-\\mu^2"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000086>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mode of Wishart 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mode of Wishart 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "(n-p-1) V \\text{ for } n\\leq p+1"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001396>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "mean of Levy 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "mean of Levy 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\infty"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000635>
+      a       <http://www.probonto.org/ontology#PROB_c0000020> ;
+      rdfs:label "t-distribution"^^<en> , "Student's t-distribution 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "Student's t-distribution 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "StudentT2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000037>
+              <http://www.probonto.org/ontology#PROB_k0000636> ;
+      <http://www.probonto.org/ontology#PROB_c0000042>
+              <http://www.probonto.org/ontology#PROB_k0000638> ;
+      <http://www.probonto.org/ontology#PROB_c0000044>
+              <http://www.probonto.org/ontology#PROB_k0000639> ;
+      <http://www.probonto.org/ontology#PROB_c0000045>
+              <http://www.probonto.org/ontology#PROB_k0000640> ;
+      <http://www.probonto.org/ontology#PROB_c0000054>
+              "x"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000059>
+              "x \\in (-\\infty,+\\infty)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000062>
+              <http://www.probonto.org/ontology#PROB_k0000642> , <http://www.probonto.org/ontology#PROB_k0000643> , <http://www.probonto.org/ontology#PROB_k0000641> .
+
+<http://www.probonto.org/ontology#PROB_k0000694>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Generalized Negative Binomial 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Generalized Negative Binomial 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "m \\theta (1-\\theta) (1-\\theta \\beta)^{-3}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000322>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "scale of Normal-inverse-gamma-1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "scale of Normal-inverse-gamma-1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000029>
+              "NormalInverseGamma1.beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000031>
+              "\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000049>
+              "\\beta > 0, \\beta \\in  R"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000051>
+              "scale"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000060>
+              "beta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001425>
+      a       <http://www.probonto.org/ontology#PROB_c0000064> ;
+      rdfs:label "relationship between Noncentral Beta 1 and Beta 1 whereby \\\\lambda = 0" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0001114> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000057> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "\\lambda = 0"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NoncentralBeta1(\\lambda, \\alpha,\\beta) \\rightarrow Beta1(\\alpha,\\beta)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "\\cite{walck2007handbook}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001228>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Maxwell Boltzmann 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Maxwell Boltzmann 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{a^2(3 \\pi - 8)}{\\pi}"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001339>
+      a       <http://www.probonto.org/ontology#PROB_c0000025> ;
+      rdfs:label "CDF of Johnson SN 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "CDF of Johnson SN 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac12 \\text{erfc}\\left[ -\\frac{\\delta + \\frac{\\delta (x-\\mu)}{\\sigma}}{\\sqrt{2}}\\right]"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/2 *erfc(-(gamma+ (delta*(x-mu)/sigma))/sqrt(2))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001355>
+      a       <http://www.probonto.org/ontology#PROB_c0000026> ;
+      rdfs:label "SF of Standard Power 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "SF of Standard Power 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "1- x^\\beta"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1- x^beta"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0001097>
+      a       <http://www.probonto.org/ontology#PROB_c0000023> ;
+      rdfs:label "PDF of Arcsine 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "PDF of Arcsine 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\frac{1}{\\pi\\sqrt{x(1-x)}}"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000083>
+              "1/pi/sqrt(x*(1-x))"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000047>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Nakagami 1" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Nakagami 1"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              "\\Omega \\Big(1-\\frac{1}{m}\\Big(\\frac{\\Gamma(m+\\frac{1}{2})}{\\Gamma(m)}\\Big)^2 \\Big)"^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000549>
+      a       <http://www.probonto.org/ontology#PROB_c0000005> ;
+      rdfs:label "variance of Frechet 2" ;
+      <http://www.probonto.org/ontology#PROB_c0000028>
+              "variance of Frechet 2"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000034>
+              """\\begin{cases}
+   \\ \\sigma^2\\left(\\Gamma\\left(1-\\frac{2}{\\alpha}\\right)- \\left(\\Gamma\\left(1-\\frac{1}{\\alpha}\\right)\\right)^2\\right)  & \\text{for } \\alpha>2  \\\\
+    \\ \\infty              & \\text{otherwise}
+\\end{cases}"""^^<en> .
+
+<http://www.probonto.org/ontology#PROB_k0000875>
+      a       <http://www.probonto.org/ontology#PROB_c0000065> ;
+      rdfs:label "relationship between Negative Binomial 4 and Negative Binomial 1 whereby p = 1 -p" ;
+      <http://www.probonto.org/ontology#PROB_c0000071>
+              <http://www.probonto.org/ontology#PROB_k0000161> ;
+      <http://www.probonto.org/ontology#PROB_c0000072>
+              <http://www.probonto.org/ontology#PROB_k0000074> ;
+      <http://www.probonto.org/ontology#PROB_c0000073>
+              "p = 1 -p"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000074>
+              "NegativeBinomial4(r,p) \\rightarrow NegativeBinomial1(r,p)"^^<en> ;
+      <http://www.probonto.org/ontology#PROB_c0000075>
+              "ProbOnto spec"^^<en> .


### PR DESCRIPTION
Based on discussion at https://github.com/EBISPOT/ols4/issues/100, OLS4 requires a version of probonto ontology file with the .ttl extension. This PR adds this to the repository.